### PR TITLE
Add psp-replacement constraints

### DIFF
--- a/gatekeeper/cluster/constraints/kustomization.yaml
+++ b/gatekeeper/cluster/constraints/kustomization.yaml
@@ -4,6 +4,21 @@ resources:
   # source-templatename.yaml
   - gatekeeper-k8sexternalips.yaml
   - gatekeeper-k8srequiredlabels.yaml
+  - psp-k8spspallowedusers.yaml
+  - psp-k8spspallowprivilegeescalationcontainer.yaml
+  - psp-k8spspapparmor.yaml
+  - psp-k8spspcapabilities.yaml
+  - psp-k8spspflexvolumes.yaml
+  - psp-k8spspforbiddensysctls.yaml
+  - psp-k8spsphostfilesystem.yaml
+  - psp-k8spsphostnamespace.yaml
+  - psp-k8spsphostnetworkingports.yaml
+  - psp-k8spspprivilegedcontainer.yaml
+  - psp-k8spspprocmount.yaml
+  - psp-k8spspreadonlyrootfilesystem.yaml
+  - psp-k8spspseccomp.yaml
+  - psp-k8spspselinuxv2.yaml
+  - psp-k8spspvolumetypes.yaml
   - semaphore-semaphoremirrornamelength.yaml
   - uw-annotationvalidation.yaml
   - uw-blocknodeport.yaml

--- a/gatekeeper/cluster/constraints/psp-k8spspallowedusers.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspallowedusers.yaml
@@ -1,0 +1,22 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowedUsers
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    runAsUser:
+      rule: MustRunAsNonRoot
+    runAsGroup:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    fsGroup:
+      rule: RunAsAny

--- a/gatekeeper/cluster/constraints/psp-k8spspallowprivilegeescalationcontainer.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspallowprivilegeescalationcontainer.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*

--- a/gatekeeper/cluster/constraints/psp-k8spspapparmor.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspapparmor.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAppArmor
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    allowedProfiles: []

--- a/gatekeeper/cluster/constraints/psp-k8spspcapabilities.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspcapabilities.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    allowedCapabilities: []

--- a/gatekeeper/cluster/constraints/psp-k8spspflexvolumes.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspflexvolumes.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPFlexVolumes
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    allowedFlexVolumes: []

--- a/gatekeeper/cluster/constraints/psp-k8spspforbiddensysctls.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspforbiddensysctls.yaml
@@ -1,0 +1,16 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPForbiddenSysctls
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    forbiddenSysctls:
+      - "*"

--- a/gatekeeper/cluster/constraints/psp-k8spsphostfilesystem.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spsphostfilesystem.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+    parameters:
+      allowedHostPaths: []

--- a/gatekeeper/cluster/constraints/psp-k8spsphostnamespace.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spsphostnamespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostNamespace
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*

--- a/gatekeeper/cluster/constraints/psp-k8spsphostnetworkingports.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spsphostnetworkingports.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostNetworkingPorts
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+    parameters:
+      hostNetwork: false

--- a/gatekeeper/cluster/constraints/psp-k8spspprivilegedcontainer.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspprivilegedcontainer.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPPrivilegedContainer
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*

--- a/gatekeeper/cluster/constraints/psp-k8spspprocmount.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspprocmount.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPProcMount
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    procMount: Default

--- a/gatekeeper/cluster/constraints/psp-k8spspreadonlyrootfilesystem.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspreadonlyrootfilesystem.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPReadOnlyRootFilesystem
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*

--- a/gatekeeper/cluster/constraints/psp-k8spspseccomp.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspseccomp.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPSeccomp
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    allowedProfiles: []

--- a/gatekeeper/cluster/constraints/psp-k8spspselinuxv2.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspselinuxv2.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPSELinuxV2
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    allowedSELinuxOptions: []

--- a/gatekeeper/cluster/constraints/psp-k8spspvolumetypes.yaml
+++ b/gatekeeper/cluster/constraints/psp-k8spspvolumetypes.yaml
@@ -1,0 +1,22 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPVolumeTypes
+metadata:
+  name: default
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    # Allow core volume types.
+    volumes:
+      - configMap
+      - emptyDir
+      - projected
+      - secret
+      - downwardAPI
+      - persistentVolumeClaim

--- a/gatekeeper/example/kube-system/constraint-psp-patch.yaml
+++ b/gatekeeper/example/kube-system/constraint-psp-patch.yaml
@@ -1,0 +1,16 @@
+# Exceptions to the default constraint for labels that use a more permissive
+# constraint
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: default
+spec:
+  match:
+    labelSelector:
+      matchExpressions:
+        - key: "uw.systems/capabilities"
+          operator: "NotIn"
+          values: ["sys_ptrace"]
+        - key: "uw.systems/capabilities"
+          operator: "NotIn"
+          values: ["ipc_lock"]

--- a/gatekeeper/example/kube-system/constraint-psp.yaml
+++ b/gatekeeper/example/kube-system/constraint-psp.yaml
@@ -1,0 +1,56 @@
+# Safety net has the widest set of capabilities that we allow cluster-wide
+# The goal is to protect ourselves from leaving a gap in the default constraint
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: safety-net
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+  parameters:
+    allowedCapabilities: ["CAP_IPC_LOCK", "SYS_PTRACE"]
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: allow-sysptrace
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+    labelSelector:
+      matchExpressions:
+        - key: "uw.systems/capabilities"
+          operator: "In"
+          values: ["sys_ptrace"]
+  parameters:
+    allowedCapabilities: ["SYS_PTRACE"]
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: allow-ipclock
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - sys-*
+    labelSelector:
+      matchExpressions:
+        - key: "uw.systems/capabilities"
+          operator: "In"
+          values: ["ipc_lock"]
+  parameters:
+    allowedCapabilities: ["CAP_IPC_LOCK"]

--- a/gatekeeper/example/kube-system/kustomization.yaml
+++ b/gatekeeper/example/kube-system/kustomization.yaml
@@ -6,5 +6,9 @@ resources:
   # templates from external repos
   - github.com/utilitywarehouse/gatekeeper-template-manifests/base
   - github.com/utilitywarehouse/semaphore-service-mirror/gatekeeper
+  - github.com/open-policy-agent/gatekeeper-library/library/pod-security-policy
+
+  - constraint-psp.yaml
 patchesStrategicMerge:
   - constraint-patch.yaml
+  - constraint-psp-patch.yaml


### PR DESCRIPTION
Attempt to replace PSP with similar constraints

This is system is very verbose if we want to control which namespaces can have exceptions to the default policies, and which labels allow those exceptions. Ideally a better replacement will come from kubernetes or the community, but if it doesn't, we have an option ready