### PR TITLE
Fix gatekeeper manifests generation

### DIFF
--- a/gatekeeper/Makefile
+++ b/gatekeeper/Makefile
@@ -1,6 +1,11 @@
 SHELL := /bin/bash
 HELM_VERSION=3.7.0
 
+# Comma separated list of supported api versions
+#
+# Needed to pass helm capability checks like https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml#L1
+API_VERSIONS=policy/v1/PodDisruptionBudget,
+
 .PHONY: helm
 helm: helm-fetch helm-cluster helm-namespaced
 
@@ -14,7 +19,7 @@ helm-fetch:
 helm-cluster: helm-fetch
 	# - Select resources without a namespace field
 	# - Exclude ClusterRoleBindings (should be set in the overlay)
-	helm template --release-name --include-crds --set postInstall.labelNamespace.enabled=false --no-hooks gatekeeper gatekeeper-$(HELM_VERSION).tgz | \
+	helm template --api-versions={$(API_VERSIONS)} --release-name --include-crds --set postInstall.labelNamespace.enabled=false --no-hooks gatekeeper gatekeeper-$(HELM_VERSION).tgz | \
 		yq eval 'select(.metadata | has("namespace") | not) | select(.kind != "ClusterRoleBinding")' - \
 		> cluster/upstream/gatekeeper.yaml
 
@@ -23,6 +28,6 @@ helm-namespaced: helm-fetch
 	# - Select resources with a namespace field
 	# - Exclude RoleBindings (should be set in the overlay)
 	# - Remove the namespace field
-	helm template --release-name gatekeeper --set postInstall.labelNamespace.enabled=false --set resourceQuota=false --no-hooks gatekeeper-$(HELM_VERSION).tgz | \
+	helm template --api-versions={$(API_VERSIONS)} --release-name gatekeeper --set postInstall.labelNamespace.enabled=false --set resourceQuota=false --no-hooks gatekeeper-$(HELM_VERSION).tgz | \
 		yq eval 'select(.metadata | has("namespace")) | select(.kind != "RoleBinding") | del(.metadata.namespace)' - \
 		> namespaced/upstream/gatekeeper.yaml

--- a/gatekeeper/namespaced/upstream/gatekeeper.yaml
+++ b/gatekeeper/namespaced/upstream/gatekeeper.yaml
@@ -1,5 +1,5 @@
 # Source: gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
Helm v3 includes a "capabilities" api to allow templating based on the
available apis. Sadly this functionality does not work with `helm
template` and all the checks fail, unless apiversions are explicitely
passed as flags.

To make the issue worse, helms checks the full api name (as in
policy/v1/PodDisruptionBudget) instead of just the group (as in
policy/v1), which is what kubernetes provides via
`kubectl api-versions`, so there's no easy way to programatically get
a the list.

As a result, I'm adding the manual API_VERSIONS variable, which we need
to maintain :(

On a side note, API_VERSIONS needs a trailing comma to be interpreted as
an array, which is what helm expects, now that it only has 1 element.