### PR TITLE
coredns: manually updating to 1.8.7

### DIFF
--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -116,7 +116,7 @@ spec:
                topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.8.6
+        image: coredns/coredns:1.8.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Upstream is slow:
https://github.com/coredns/deployment/pull/264

1.8.6 has been soaking for a few days, I would like to do the same with 1.8.7 before moving to dev.