### PR TITLE
external-dns: adding pod limits and requests

### DIFF
--- a/external-dns/patches/deploy.yaml
+++ b/external-dns/patches/deploy.yaml
@@ -9,3 +9,13 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "7979"
         prometheus.io/scrape: "true"
+    spec:
+      containers:
+        - name: external-dns
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "10m"
+              memory: "128Mi"


### PR DESCRIPTION
Based on:
https://github.com/utilitywarehouse/kubernetes-manifests/pull/54137/files

It should be everywhere.