### PR TITLE
Add aws-ebs-csi-driver base and point to v1.6.0 upstream.

### DIFF
--- a/aws-ebs-csi-driver/README.md
+++ b/aws-ebs-csi-driver/README.md
@@ -1,0 +1,6 @@
+Uses kustomize base from https://github.com/kubernetes-sigs/aws-ebs-csi-driver
+to deploy the CSI driver.
+
+Additionally, it patches the controller deployment to run on masters and utilise
+the respective EC2 instance role, instead of using AWS credentials.
+We also patch the daemonset ClusterRole to allow scheduling on our nodes.

--- a/aws-ebs-csi-driver/clusterrole-csi-node-patch.yaml
+++ b/aws-ebs-csi-driver/clusterrole-csi-node-patch.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /rules/0
+  value:
+    apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - ebs-csi-node

--- a/aws-ebs-csi-driver/controller-patch.yaml
+++ b/aws-ebs-csi-driver/controller-patch.yaml
@@ -1,0 +1,22 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ebs-csi-controller
+spec:
+  template:
+    spec:
+      tolerations:
+        # Mark the pod so it can be scheduled on master nodes.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      # Deploy on masters to be able to get credentials/permissions from the node
+      nodeSelector:
+        role: master
+      containers:
+        - name: ebs-plugin
+          # Delete the expected aws credentials
+          env:
+            - $patch: delete
+              name: AWS_ACCESS_KEY_ID
+            - $patch: delete
+              name: AWS_SECRET_ACCESS_KEY

--- a/aws-ebs-csi-driver/ebs-csi-node-psp.yaml
+++ b/aws-ebs-csi-driver/ebs-csi-node-psp.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: ebs-csi-node
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  volumes:
+    - "*"
+  allowedHostPaths:
+    - pathPrefix: "/dev"
+    - pathPrefix: "/var/lib/kubelet"
+    - pathPrefix: "/var/lib/kubelet/plugins/ebs.csi.aws.com/"
+    - pathPrefix: "/var/lib/kubelet/plugins_registry/"

--- a/aws-ebs-csi-driver/kustomization.yaml
+++ b/aws-ebs-csi-driver/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ebs-csi-node-psp.yaml
+
+  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/base?ref=v1.6.0
+patchesStrategicMerge:
+  - controller-patch.yaml
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: ebs-csi-node-role
+    path: clusterrole-csi-node-patch.yaml


### PR DESCRIPTION
This add a base that uses the remote kustomize base aws-ebs-csi-driver offers
and patches to deploy the controller on master nodes and allow daemonset pods to
be scheduled on nodes.