### PR TITLE
Enable background checks for kyverno hostPaths policy

### DIFF
--- a/kyverno/policies/pods/hostPaths.yaml
+++ b/kyverno/policies/pods/hostPaths.yaml
@@ -13,7 +13,7 @@ metadata:
       paths should be disabled by default, except for specific cases
 spec:
   validationFailureAction: enforce
-  background: false
+  background: true
   rules:
     - name: restrict-hostpath-volumes
       match:


### PR DESCRIPTION
We use it for all the other policies and could be useful when rolling to new
envs on audit only mode to check for potential violations.