### PR TITLE
Include kube-system resources under kyverno scope

### DIFF
--- a/kyverno/deployment-patch.yaml
+++ b/kyverno/deployment-patch.yaml
@@ -1,0 +1,14 @@
+# Do not filte kube-system resources:
+# https://github.com/kyverno/kyverno/blob/release-1.6/config/release/install.yaml#L7873
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kyverno
+spec:
+  template:
+    spec:
+      containers:
+        - args:
+            - --filterK8sResources=[Event,*,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]
+            - -v=2
+          name: kyverno

--- a/kyverno/kustomization.yaml
+++ b/kyverno/kustomization.yaml
@@ -7,4 +7,6 @@ resources:
 - policies/
 patchesStrategicMerge:
 - delete-ns.yaml
+- deployment-patch.yaml
+- kyverno-config-patch.yaml
 - metrics-svc-patch.yaml

--- a/kyverno/kyverno-config-patch.yaml
+++ b/kyverno/kyverno-config-patch.yaml
@@ -1,0 +1,11 @@
+# Kyverno upstream deployment config excludes kube-system resources by default:
+# https://github.com/kyverno/kyverno/blob/main/config/install.yaml#L7528-L7530
+# Since we deploy a lot of things under kube-system, let's not exclude it
+# blindly, but cater for kube-system resources in our policies.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+data:
+  excludeGroupRole: system:nodes,system:kube-scheduler
+  resourceFilters: "[Event,*,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]"


### PR DESCRIPTION
Vanilla kyverno base is excluding resources under kube-system namespace from
kyverno policies. Since we deploy a lot of controllers under that namespace, it
would be preferable for kyverno to audit the namespace and apply rules.