### PR TITLE
Increase kyverno replicas to 3

### DIFF
--- a/kyverno/deployment-patch.yaml
+++ b/kyverno/deployment-patch.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   name: kyverno
 spec:
+  replicas: 3 # the recommended replica counts for HA is at least 3: https://kyverno.io/docs/high-availability/
   template:
     spec:
       containers:


### PR DESCRIPTION
According to the docs: https://kyverno.io/docs/high-availability/ 3 is the
least recommended size of the deployment for HA setups. We need HA, otherwise
admission requests will fail while kyverno is down