### PR TITLE
Fix kyverno validation rules for using host namespace

### DIFF
--- a/kyverno/policies/pods/hostIPC.yaml
+++ b/kyverno/policies/pods/hostIPC.yaml
@@ -1,9 +1,9 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-ipc-containers
+  name: disallow-host-ipc-pods
   annotations:
-    policies.kyverno.io/title: Disallow HostIPC Containers
+    policies.kyverno.io/title: Disallow HostIPC Pods
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
@@ -21,13 +21,8 @@ spec:
                 - Pod
       validate:
         message: >-
-          HostIPC containers are disallowed. The field spec.containers[*].hostIPC
-          must be unset or set to `false`.
+          HostIPC pods are disallowed. The field spec.hostIPC must be unset or
+          set to `false`.
         pattern:
           spec:
-            =(ephemeralContainers):
-              - =(hostIPC): "false"
-            =(initContainers):
-              - =(hostIPC): "false"
-            containers:
-              - =(hostIPC): "false"
+            =(hostIPC): "false"

--- a/kyverno/policies/pods/hostNetwork.yaml
+++ b/kyverno/policies/pods/hostNetwork.yaml
@@ -1,9 +1,9 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-network-containers
+  name: disallow-host-network-pods
   annotations:
-    policies.kyverno.io/title: Disallow HostNetwork Containers
+    policies.kyverno.io/title: Disallow HostNetwork Pods
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
@@ -21,13 +21,8 @@ spec:
                 - Pod
       validate:
         message: >-
-          HostNetwork containers are disallowed. The field spec.containers[*].hostNetwork
-          must be unset or set to `false`.
+          HostNetwork pods are disallowed. The field spec.hostNetwork must be
+          unset or set to `false`.
         pattern:
           spec:
-            =(ephemeralContainers):
-              - =(hostNetwork): "false"
-            =(initContainers):
-              - =(hostNetwork): "false"
-            containers:
-              - =(hostNetwork): "false"
+            =(hostNetwork): "false"

--- a/kyverno/policies/pods/hostPID.yaml
+++ b/kyverno/policies/pods/hostPID.yaml
@@ -1,9 +1,9 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-pid-containers
+  name: disallow-host-pid-pods
   annotations:
-    policies.kyverno.io/title: Disallow HostPID Containers
+    policies.kyverno.io/title: Disallow HostPID Pods
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
@@ -21,13 +21,8 @@ spec:
                 - Pod
       validate:
         message: >-
-          HostPID containers are disallowed. The field spec.containers[*].hostPID
-          must be unset or set to `false`.
+          HostPID pods are disallowed. The field spec.hostPID must be unset or
+          set to `false`.
         pattern:
           spec:
-            =(ephemeralContainers):
-              - =(hostPID): "false"
-            =(initContainers):
-              - =(hostPID): "false"
-            containers:
-              - =(hostPID): "false"
+            =(hostPID): "false"

--- a/kyverno/policies/pods/test/kyverno-test.yaml
+++ b/kyverno/policies/pods/test/kyverno-test.yaml
@@ -9,33 +9,33 @@ resources:
   - test-privilege-escalation.yaml
 results:
 # Test hostIPC
-  - policy: disallow-host-ipc-containers
+  - policy: disallow-host-ipc-pods
     rule: default
     resource: test-hostIPC-not-set
     kind: Pod
     result: pass
-  - policy: disallow-host-ipc-containers
+  - policy: disallow-host-ipc-pods
     rule: default
     resource: test-hostIPC-set-to-false
     kind: Pod
     result: pass
-  - policy: disallow-host-ipc-containers
+  - policy: disallow-host-ipc-pods
     rule: default
     resource: test-hostIPC-set-to-true
     kind: Pod
     result: fail
 # Test hostNetwork
-  - policy: disallow-host-network-containers
+  - policy: disallow-host-network-pods
     rule: default
     resource: test-hostNetwork-not-set
     kind: Pod
     result: pass
-  - policy: disallow-host-network-containers
+  - policy: disallow-host-network-pods
     rule: default
     resource: test-hostNetwork-set-to-false
     kind: Pod
     result: pass
-  - policy: disallow-host-network-containers
+  - policy: disallow-host-network-pods
     rule: default
     resource: test-hostNetwork-set-to-true
     kind: Pod

--- a/kyverno/policies/pods/test/test-hostIPC.yaml
+++ b/kyverno/policies/pods/test/test-hostIPC.yaml
@@ -4,11 +4,9 @@ metadata:
   name: test-hostIPC-not-set
   labels:
     app: test-hostIPC-not-set
-  namespace: test
 spec:
   containers:
-  - name: alpine
-    image: alpine
+  - name: test
 ---
 apiVersion: v1
 kind: Pod
@@ -16,12 +14,10 @@ metadata:
   name: test-hostIPC-set-to-false
   labels:
     app: test-hostIPC-set-to-false
-  namespace: test
 spec:
+  hostIPC: false
   containers:
-  - name: alpine
-    image: alpine
-    hostIPC: false
+  - name: test
 ---
 apiVersion: v1
 kind: Pod
@@ -29,9 +25,7 @@ metadata:
   name: test-hostIPC-set-to-true
   labels:
     app: test-hostIPC-set-to-true
-  namespace: test
 spec:
+  hostIPC: true
   containers:
-  - name: alpine
-    image: alpine
-    hostIPC: true
+  - name: test

--- a/kyverno/policies/pods/test/test-hostNetwork.yaml
+++ b/kyverno/policies/pods/test/test-hostNetwork.yaml
@@ -4,11 +4,9 @@ metadata:
   name: test-hostNetwork-not-set
   labels:
     app: test-hostNetwork-not-set
-  namespace: test
 spec:
   containers:
-  - name: alpine
-    image: alpine
+  - name: test
 ---
 apiVersion: v1
 kind: Pod
@@ -16,12 +14,10 @@ metadata:
   name: test-hostNetwork-set-to-false
   labels:
     app: test-hostNetwork-set-to-false
-  namespace: test
 spec:
+  hostNetwork: false
   containers:
-  - name: alpine
-    image: alpine
-    hostNetwork: false
+  - name: test
 ---
 apiVersion: v1
 kind: Pod
@@ -29,9 +25,7 @@ metadata:
   name: test-hostNetwork-set-to-true
   labels:
     app: test-hostNetwork-set-to-true
-  namespace: test
 spec:
+  hostNetwork: true
   containers:
-  - name: alpine
-    image: alpine
-    hostNetwork: true
+  - name: test


### PR DESCRIPTION
Host namespace attributes are specified under `spec` and are not particular to
the pods containers. Example policy:
https://kyverno.io/policies/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces/