### PR TITLE
Kyverno policies adjustments

### DIFF
--- a/kyverno/policies/ingress/disallow-default-tsloptions.yaml
+++ b/kyverno/policies/ingress/disallow-default-tsloptions.yaml
@@ -15,7 +15,7 @@ metadata:
       only a cluster-admin can create the `default` TLSOption resource.
 spec:
   validationFailureAction: enforce
-  background: false
+  background: true
   rules:
   - name: disallow-default-tlsoptions
     match:

--- a/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
+++ b/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
@@ -12,7 +12,7 @@ metadata:
       in order to allow deletion.
 spec:
   validationFailureAction: enforce
-  background: true
+  background: false
   rules:
   - name: require-annotation-before-deleting
     match:

--- a/kyverno/policies/pods/hostPaths.yaml
+++ b/kyverno/policies/pods/hostPaths.yaml
@@ -23,11 +23,9 @@ spec:
                 - Pod
       preconditions:
         all:
-          - key: "{{request.operation}}"
-            operator: In
-            value:
-              - CREATE
-              - UPDATE
+          - key: "{{ request.operation }}"
+            operator: NotEquals
+            value: DELETE
       validate:
         message: HostPath volumes are not allowed.
         deny:


### PR DESCRIPTION
- Disable/enable background checks based on whether the policy is valuable only
  on admission request or background can point to a violation
- Change hostPaths policy precondition to workaround the background check error:
`policy 'hostpath-vols' (Validation) rule 'autogen-restrict-hostpath-volumes' failed. preconditions not met`