### PR TITLE
kyverno: Add a policy to disallow pods to set hostPorts

### DIFF
--- a/kyverno/audit-only/audit-only.yaml
+++ b/kyverno/audit-only/audit-only.yaml
@@ -86,6 +86,13 @@ spec:
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
+  name: disallow-host-ports
+spec:
+  validationFailureAction: audit
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
   name: restrict-scheduling-to-master-nodes
 spec:
   validationFailureAction: audit

--- a/kyverno/base/policies/pods/hostPorts.yaml
+++ b/kyverno/base/policies/pods/hostPorts.yaml
@@ -1,0 +1,40 @@
+# https://kyverno.io/policies/pod-security/baseline/disallow-host-ports/disallow-host-ports/
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-host-ports
+  annotations:
+    policies.kyverno.io/title: Disallow hostPorts
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Access to host ports allows potential snooping of network traffic and should not be
+      allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
+      field is unset or set to `0`.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: host-ports-none
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: >-
+          Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort
+          , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
+          must either be unset or set to `0`.
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - =(ports):
+                  - =(hostPort): 0
+            =(initContainers):
+              - =(ports):
+                  - =(hostPort): 0
+            containers:
+              - =(ports):
+                  - =(hostPort): 0

--- a/kyverno/base/policies/pods/kustomization.yaml
+++ b/kyverno/base/policies/pods/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - hostNetwork.yaml
 - hostPaths.yaml
 - hostPID.yaml
+- hostPorts.yaml
 - pod-node-restriction.yaml
 - privileged.yaml
 - privilege-escalation.yaml


### PR DESCRIPTION
Surfaced by running kubernetes-sigs/multi-tenancy benchmarks and will allow
passing test:
```
|  12 | MTB-PL1-BC-HI-3  | Block use of host networking and ports | Failed  |
```
Even though this test seems to be broken, the policy to disallow host ports on
pods is considered best practice for multi-tenant clusters.