### PR TITLE
Disable background checks for noisy kyverno policies

### DIFF
--- a/kyverno/base/policies/serviceaccounts/vault-annotation.yaml
+++ b/kyverno/base/policies/serviceaccounts/vault-annotation.yaml
@@ -12,7 +12,7 @@ metadata:
       arn
 spec:
   validationFailureAction: enforce
-  background: true
+  background: false # Disable due to warning events noise.
   rules:
     - name: default
       match:

--- a/kyverno/base/policies/services/externalName.yaml
+++ b/kyverno/base/policies/services/externalName.yaml
@@ -13,7 +13,7 @@ metadata:
       if the externalName field refers to localhost.
 spec:
   validationFailureAction: enforce
-  background: true
+  background: false # Disable due to warning events noise: https://github.com/kyverno/kyverno/issues/4093
   rules:
     - name: default
       match:


### PR DESCRIPTION
We should re-enable after we get some kyverno feedback and figure out the
behaviour.
For the vault annotation policy, the existing gatekeeper rules will offer us
solid ground for migration without missing any violation in environments.