### PR TITLE
Fixes Kyverno policies

### DIFF
--- a/kyverno/base/policies/ingress/require-ingress-host.yaml
+++ b/kyverno/base/policies/ingress/require-ingress-host.yaml
@@ -18,7 +18,7 @@ spec:
     match:
       resources:
         kinds:
-        - ingress
+        - Ingress # Starting with capital letter seems to be significant for policy validation on admission
     validate:
       message: "Ingresses must specify a host"
       pattern:

--- a/kyverno/base/policies/pods/hostPorts.yaml
+++ b/kyverno/base/policies/pods/hostPorts.yaml
@@ -13,7 +13,7 @@ metadata:
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: enforce
   background: true
   rules:
     - name: host-ports-none


### PR DESCRIPTION
- Specifying resources starting with capita letter seems to be significant for
  kyverno tgo validate rules. Using `ingress` as resource kind raised the
  following error on kube-applier:
```
Error from server: error when applying patch:
{"spec":{"rules":[{"match":{"resources":{"kinds":["ingress"]}},"name":"require-ingress-host","validate":{"message":"Ingresses must specify a host","pattern":{"spec":{"rules":[{"host":"*?"}]}}}}]}}
to:
Resource: "kyverno.io/v1, Resource=clusterpolicies", GroupVersionKind: "kyverno.io/v1, Kind=ClusterPolicy"
Name: "require-ingress-host", Namespace: ""
for: "STDIN": admission webhook "validate-policy.kyverno.svc" denied the request: match resource kind is invalid: unable to convert GVK to GVR for kinds [ingress], err: kind 'ingress' not found in apiVersion ''
```
- Changing hostPorts policy strategy to `enforce`