### PR TITLE
Add kyverno policies to protect traefik IngressRoute(TCP)

### DIFF
--- a/kyverno/audit-only/audit-only.yaml
+++ b/kyverno/audit-only/audit-only.yaml
@@ -12,7 +12,28 @@ spec:
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
+  name: disallow-or-operator
+spec:
+  validationFailureAction: audit
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-wildcard-hostsni
+spec:
+  validationFailureAction: audit
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
   name: require-ingress-host
+spec:
+  validationFailureAction: audit
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ingressroute-host
 spec:
   validationFailureAction: audit
 ---

--- a/kyverno/base/policies/ingress/disallow-or-operator.yaml
+++ b/kyverno/base/policies/ingress/disallow-or-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-or-operator
+  annotations:
+    policies.kyverno.io/title: Disallow OR Operator
+    policies.kyverno.io/category: Traefik
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: IngressRoute,IngressRouteTCP
+    policies.kyverno.io/description: >-
+      Using || can allow you to subvert other restrictions and hijack traffic
+      with non-specific rules that match generic paths or headers
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: default
+      match:
+        any:
+          - resources:
+              kinds:
+                - IngressRoute
+                - IngressRouteTCP
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: NotEquals
+            value: DELETE
+      validate:
+        message: "Route matches must not contain ||"
+        foreach:
+          - list: request.object.spec.routes
+            deny:
+              conditions:
+                all:
+                  - key: >-
+                      {{ element.match | regex_match('\|\|', @) }}
+                    operator: Equals
+                    value: true

--- a/kyverno/base/policies/ingress/disallow-wildcard-hostsni.yaml
+++ b/kyverno/base/policies/ingress/disallow-wildcard-hostsni.yaml
@@ -1,0 +1,41 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-wildcard-hostsni
+  annotations:
+    policies.kyverno.io/title: Disallow Wildcard HostSNI
+    policies.kyverno.io/category: Traefik
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: IngressRouteTCP
+    policies.kyverno.io/description: >-
+      Prevent IngressRouteTCP from hijacking all traffic by preventing wildcard
+      HostSNIs.
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: default
+      match:
+        any:
+          - resources:
+              kinds:
+                - IngressRouteTCP
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.routes[?contains(keys(@), 'match')] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+          - key: "{{ request.operation }}"
+            operator: NotEquals
+            value: DELETE
+      validate:
+        message: "HostSNI rules must not contain a wildcard host '*'"
+        foreach:
+          - list: request.object.spec.routes
+            deny:
+              conditions:
+                all:
+                  - key: >-
+                      {{ element.match | regex_match('HostSNI\(`.*\*+.*`\)', @) }}
+                    operator: Equals
+                    value: true

--- a/kyverno/base/policies/ingress/kustomization.yaml
+++ b/kyverno/base/policies/ingress/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - disallow-default-tsloptions.yaml
+- disallow-or-operator.yaml
+- disallow-wildcard-hostsni.yaml
 - require-ingress-host.yaml
+- require-ingressroute-host.yaml

--- a/kyverno/base/policies/ingress/require-ingressroute-host.yaml
+++ b/kyverno/base/policies/ingress/require-ingressroute-host.yaml
@@ -1,0 +1,42 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ingressroute-host
+  annotations:
+    policies.kyverno.io/title: Require IngressRoutes Host Specification
+    policies.kyverno.io/category: Traefik
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: IngressRoute
+    policies.kyverno.io/description: >-
+      Every IngressRoute match must contain a specific host with a valid
+      hostname as defined by RFC 1123. By requiring a Host rule, we prevent
+      widespread hijacking by non-specific rules like PathPrefix(`/`).
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: default
+      match:
+        any:
+          - resources:
+              kinds:
+                - IngressRoute
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: NotEquals
+            value: DELETE
+      validate:
+        message: "All route matches must contain a Host rule with valid hostnames as defined by RFC 1123"
+        foreach:
+          - list: request.object.spec.routes
+            deny:
+              conditions:
+                all:
+                  # The regular expression used here was adapted from the validation Kubernetes
+                  # performs on the host field of Ingress rules, which adheres to RFC 1123:
+                  # - https://github.com/kubernetes/kubernetes/blob/18856dace935db46d3ba84374ce23438922e272b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L198
+                  - key: >-
+                      {{ element.match | regex_match('Host\((`(([a-zA-Z0-9]{1,})|([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,})`(, ?)?)+\)', @) }}
+                    operator: Equals
+                    value: false

--- a/kyverno/base/policies/ingress/test/kyverno-test.yaml
+++ b/kyverno/base/policies/ingress/test/kyverno-test.yaml
@@ -1,0 +1,78 @@
+name: test-ingress-and-traefik-resources
+policies:
+  - ../disallow-or-operator.yaml
+  - ../disallow-wildcard-hostsni.yaml
+  - ../require-ingressroute-host.yaml
+resources:
+  - test-disallow-or-operator.yaml
+  - test-disallow-wildcard-hostsni.yaml
+  - test-require-ingressroute-host.yaml
+results:
+# Test OR operator
+  - policy: disallow-or-operator
+    rule: default
+    resource: test-or-operator-not-allowed-IngressRouteTCP
+    kind: IngressRouteTCP
+    result: fail
+  - policy: disallow-or-operator
+    rule: default
+    resource: test-or-operator-not-allowed-IngressRoute
+    kind: IngressRoute
+    result: fail
+  - policy: disallow-or-operator
+    rule: default
+    resource: test-or-operator-complex-not-allowed-IngressRoute
+    kind: IngressRoute
+    result: fail
+  - policy: disallow-or-operator
+    rule: default
+    resource: test-or-operator-valid
+    kind: IngressRoute
+    result: pass
+# Test Wildcard HostSNI for ingressRouteTCP resources
+  - policy: disallow-wildcard-hostsni
+    rule: default
+    resource: test-wildcard-hostsni-not-allowed
+    kind: IngressRouteTCP
+    result: fail
+  - policy: disallow-wildcard-hostsni
+    rule: default
+    resource: test-wildcard-subdomain-hostsni-not-allowed
+    kind: IngressRouteTCP
+    result: fail
+  - policy: disallow-wildcard-hostsni
+    rule: default
+    resource: test-wildcard-hostsni-not-allowed-multiple-routes
+    kind: IngressRouteTCP
+    result: fail
+  - policy: disallow-wildcard-hostsni
+    rule: default
+    resource: test-wildcard-hostsni-match-missing
+    kind: IngressRouteTCP
+    result: skip
+  - policy: disallow-wildcard-hostsni
+    rule: default
+    resource: test-valid-hostsni
+    kind: IngressRouteTCP
+    result: pass
+# Test Ingress Route Require Host
+  - policy: require-ingressroute-host
+    rule: default
+    resource: test-require-ingressroute-host-missing
+    kind: IngressRoute
+    result: fail
+  - policy: require-ingressroute-host
+    rule: default
+    resource: test-require-ingressroute-bad-host
+    kind: IngressRoute
+    result: fail
+  - policy: require-ingressroute-host
+    rule: default
+    resource: test-require-ingressroute-host-valid
+    kind: IngressRoute
+    result: pass
+  - policy: require-ingressroute-host
+    rule: default
+    resource: test-require-ingressroute-host-valid-with-path
+    kind: IngressRoute
+    result: pass

--- a/kyverno/base/policies/ingress/test/test-disallow-or-operator.yaml
+++ b/kyverno/base/policies/ingress/test/test-disallow-or-operator.yaml
@@ -1,0 +1,31 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-or-operator-not-allowed-IngressRouteTCP
+spec:
+  routes:
+  - match: HostSNI(`||`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-or-operator-not-allowed-IngressRoute
+spec:
+  routes:
+  - match: Host(`||`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-or-operator-complex-not-allowed-IngressRoute
+spec:
+  routes:
+  - match: Host(`example.com || example.co.uk`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-or-operator-valid
+spec:
+  routes:
+  - match: Host(`example.com`)

--- a/kyverno/base/policies/ingress/test/test-disallow-wildcard-hostsni.yaml
+++ b/kyverno/base/policies/ingress/test/test-disallow-wildcard-hostsni.yaml
@@ -1,0 +1,42 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-wildcard-hostsni-not-allowed
+spec:
+  routes:
+  - match: HostSNI(`*`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-wildcard-subdomain-hostsni-not-allowed
+spec:
+  routes:
+  - match: HostSNI(`*.example.com`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-wildcard-hostsni-not-allowed-multiple-routes
+spec:
+  routes:
+  - match: HostSNI(`example.com`)
+    priority: 10
+  - match: HostSNI(`*`)
+    priority: 20
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-wildcard-hostsni-match-missing
+spec:
+  routes:
+  - priority: 10
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test-valid-hostsni
+spec:
+  routes:
+  - match: HostSNI(`example.com`)

--- a/kyverno/base/policies/ingress/test/test-require-ingressroute-host.yaml
+++ b/kyverno/base/policies/ingress/test/test-require-ingressroute-host.yaml
@@ -1,0 +1,31 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-require-ingressroute-host-missing
+spec:
+  routes:
+  - match: PathPrefix(`/`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-require-ingressroute-bad-host
+spec:
+  routes:
+  - match: Host(`example.c`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-require-ingressroute-host-valid
+spec:
+  routes:
+  - match: Host(`example.com`)
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-require-ingressroute-host-valid-with-path
+spec:
+  routes:
+  - match: "Host(`example.com`) && PathPrefix(`/`)"


### PR DESCRIPTION
This translates the Gatekeeper rules for traefik resources defined here:
https://github.com/utilitywarehouse/system-manifests/blob/master/gatekeeper/cluster/constraints/uw-ingressroutematchrestriction.yaml
into Kyverno policies. It also adds tests to verify the expected behaviour and
updates audit-only base to include the new policies with simple audit
validation policy.