### PR TITLE
Allow dev enablement owner

### DIFF
--- a/gatekeeper/cluster/constraints/gatekeeper-k8srequiredlabels.yaml
+++ b/gatekeeper/cluster/constraints/gatekeeper-k8srequiredlabels.yaml
@@ -14,4 +14,4 @@ spec:
       https://github.com/utilitywarehouse/documentation/tree/master/infra#structure
     labels:
       - key: "uw.systems/owner"
-        allowedRegex: "^(bill|billing|btg-operations|btg-security|cbc|contact-channels|crm|customer|customer-platform|data|digital-support|energy|insurance|partner|payment|system|telecom|unicom)$"
+        allowedRegex: "^(bill|billing|btg-operations|btg-security|cbc|contact-channels|crm|customer|customer-platform|data|dev-enablement|digital-support|energy|insurance|partner|payment|system|telecom|unicom)$"

--- a/kyverno/base/policies/namespaces/require-ns-owner-label.yaml
+++ b/kyverno/base/policies/namespaces/require-ns-owner-label.yaml
@@ -26,4 +26,4 @@ spec:
       pattern:
         metadata:
           labels:
-            uw.systems/owner: "bill|billing|btg-operations|btg-security|cbc|contact-channels|crm|customer|customer-platform|data|digital-support|energy|insurance|partner|payment|system|telecom|unicom"
+            uw.systems/owner: "bill|billing|btg-operations|btg-security|cbc|contact-channels|crm|customer|customer-platform|data|dev-enablement|digital-support|energy|insurance|partner|payment|system|telecom|unicom"


### PR DESCRIPTION
We're going to be exploring the idea of developer enablement & want to create a new namespace. 
It doesn't fit under any existing team and so want to represent it with a new owner.

I'm presuming we've migrated over to kyverno and this is the correct place to update the policy rule.

If you could be so kind to roll this out to all the clusters that would be super helpful, happy to also raise a PR for each cluster updating the kustomize base if you'd prefer.