### PR TITLE
Update gcp-compute-persistent-disk-csi-driver to v1.7.2

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
+++ b/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
@@ -6,6 +6,6 @@ kind: Kustomization
 # kube-system to play with the method we apply cluster resources via KA
 namespace: kube-system
 bases:
-  - github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.3.4
+  - github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/overlays/stable-1-23?ref=v1.7.2
 patchesStrategicMerge:
   - csi-gce-pd-controller-patch.yaml


### PR DESCRIPTION
Use stable base for kube 1.23, which includes psps and matches our existing kube
deployments version. We should switch to stable 1-24 when we update our clusters