### PR TITLE
Specify PodDisruptionBudget for Kyverno

### DIFF
--- a/kyverno/base/kustomization.yaml
+++ b/kyverno/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: kube-system
 resources:
 - github.com/kyverno/kyverno/config/release?ref=v1.7.0
+- kyverno-pdb.yaml
 
 - policies/
 patchesStrategicMerge:

--- a/kyverno/base/kyverno-pdb.yaml
+++ b/kyverno/base/kyverno-pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kyverno
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kyverno


### PR DESCRIPTION
In corner cases, where all kyverno pods are scheduled on the same node, a node
drain can kill all pods at the same time and cause all admission requests to
stuck waiting for kyverno responses. We saw this happening on a cluster with
only 2 master nodes (exp-1-merit).