### PR TITLE
Configure Kyverno to set FailurePolicy to Ignore in webhooks

### DIFF
--- a/kyverno/base/deployment-args-patch.yaml
+++ b/kyverno/base/deployment-args-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kyverno
+spec:
+  template:
+    spec:
+      containers:
+        - args:
+            - -v=2
+            - --autogenInternals=false
+            - --autoUpdateWebhooks=false
+          name: kyverno

--- a/kyverno/base/kustomization.yaml
+++ b/kyverno/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - policies/
 patchesStrategicMerge:
 - delete-ns.yaml
+- deployment-args-patch.yaml
 - deployment-master-schedule-patch.yaml
 - deployment-replicas-patch.yaml
 - kyverno-config-patch.yaml


### PR DESCRIPTION
Using flag -autoUpdateWebhooks=false will configure Kyverno to create the
default webhook configurations that forwards admission requests for all
resources and with FailurePolicy set to Ignore.
https://kyverno.io/docs/installation/#webhooks

That will allow us to pass all admission requests when Kyverno is crashing, and
we should rely on background checks and alerts to catch potential violations
during Kyverno downtoimes.
Example of current failure:
```
k delete pods kafka-0
Error from server (InternalError): Internal error occurred: failed calling webhook "validate.kyverno.svc-fail": failed to call webhook: Post "https://kyverno-svc.kube-system.svc:443/validate?timeout=10s": dial tcp 10.5.75.191:443: connect: connection refused
```