### PR TITLE
Update aws-ebs-csi-driver to v1.10.0

### DIFF
--- a/aws-ebs-csi-driver/kustomization.yaml
+++ b/aws-ebs-csi-driver/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/base?ref=v1.6.0
+  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=f6c2b16717b635376e438fc29525db94054d002d # v1.10.0
 patchesStrategicMerge:
   - controller-patch.yaml
   - daemonset-patch.yaml


### PR DESCRIPTION
Use commit ref instead of tag, since their tags are lagging one version in the
manifests images