### PR TITLE
Allow pod and serviceaccount admission when Kyverno is down

### DIFF
--- a/kyverno/base/policies/pods/AppArmor.yaml
+++ b/kyverno/base/policies/pods/AppArmor.yaml
@@ -15,6 +15,7 @@ metadata:
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: app-armor

--- a/kyverno/base/policies/pods/SELinux.yaml
+++ b/kyverno/base/policies/pods/SELinux.yaml
@@ -12,6 +12,7 @@ metadata:
       ensures that the `seLinuxOptions` field is undefined.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: selinux-type

--- a/kyverno/base/policies/pods/Seccomp.yaml
+++ b/kyverno/base/policies/pods/Seccomp.yaml
@@ -13,6 +13,7 @@ metadata:
       set to `RuntimeDefault` or `Localhost`.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: check-seccomp

--- a/kyverno/base/policies/pods/capabilities.yaml
+++ b/kyverno/base/policies/pods/capabilities.yaml
@@ -14,6 +14,7 @@ metadata:
       https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/hostIPC.yaml
+++ b/kyverno/base/policies/pods/hostIPC.yaml
@@ -11,6 +11,7 @@ metadata:
       This policy ensures Pods do not use the host's IPC namespace
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/hostNetwork.yaml
+++ b/kyverno/base/policies/pods/hostNetwork.yaml
@@ -11,6 +11,7 @@ metadata:
       This policy ensures Pods do not use the host's network interfaces.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/hostPID.yaml
+++ b/kyverno/base/policies/pods/hostPID.yaml
@@ -11,6 +11,7 @@ metadata:
       This policy ensures Pods cannot use host's PID.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/hostPaths.yaml
+++ b/kyverno/base/policies/pods/hostPaths.yaml
@@ -13,6 +13,7 @@ metadata:
       paths should be disabled by default, except for specific cases
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: restrict-hostpath-volumes

--- a/kyverno/base/policies/pods/hostPorts.yaml
+++ b/kyverno/base/policies/pods/hostPorts.yaml
@@ -14,6 +14,7 @@ metadata:
       field is unset or set to `0`.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: host-ports-none

--- a/kyverno/base/policies/pods/pod-node-restriction.yaml
+++ b/kyverno/base/policies/pods/pod-node-restriction.yaml
@@ -13,6 +13,7 @@ metadata:
       with the taint key `node-role.kubernetes.io/master`.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
   - name: restrict-scheduling-to-master

--- a/kyverno/base/policies/pods/privilege-escalation.yaml
+++ b/kyverno/base/policies/pods/privilege-escalation.yaml
@@ -13,6 +13,7 @@ metadata:
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/privileged.yaml
+++ b/kyverno/base/policies/pods/privileged.yaml
@@ -13,6 +13,7 @@ metadata:
       ensures Pods do not call for privileged mode.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: default

--- a/kyverno/base/policies/pods/procMount.yaml
+++ b/kyverno/base/policies/pods/procMount.yaml
@@ -14,6 +14,7 @@ metadata:
       server.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: check-proc-mount

--- a/kyverno/base/policies/pods/sysctls.yaml
+++ b/kyverno/base/policies/pods/sysctls.yaml
@@ -16,6 +16,7 @@ metadata:
       a Pod.
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: check-sysctls

--- a/kyverno/base/policies/serviceaccounts/vault-annotation.yaml
+++ b/kyverno/base/policies/serviceaccounts/vault-annotation.yaml
@@ -12,6 +12,7 @@ metadata:
       arn
 spec:
   validationFailureAction: enforce
+  failurePolicy: Ignore
   background: false # Disable due to warning events noise.
   rules:
     - name: default


### PR DESCRIPTION
Kyverno supports granular configuration of webhooks to controll what is allowed when a hook is down: https://kyverno.io/docs/installation/#webhooks We should allow all pods and serviceaccounts to be admitted by setting `failurePolicy` to `Ignore` https://kyverno.io/docs/writing-policies/policy-settings/ but still protect the cluster resources like ingresses that can lead to wider service disruption in case of misconfigurations.