### PR TITLE
added policy for argocd application resource

### DIFF
--- a/kyverno/base/policies/Dockerfile
+++ b/kyverno/base/policies/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:alpine
+FROM alpine:latest
 
-RUN \
-  apk add --no-cache gcc git make musl-dev \
-  && git clone https://github.com/kyverno/kyverno \
-  && cd kyverno \
-  && make cli \
-  && mv ./cmd/cli/kubectl-kyverno/kyverno /usr/local/bin/kyverno
+RUN apk --no-cache add curl tar
+
+ENV VERSION=v1.7.5
+
+RUN curl -LO https://github.com/kyverno/kyverno/releases/download/${VERSION}/kyverno-cli_${VERSION}_linux_x86_64.tar.gz && \
+    tar -xvf kyverno-cli_${VERSION}_linux_x86_64.tar.gz && \
+    cp kyverno /usr/local/bin/
 
 CMD [ "/usr/local/bin/kyverno" ]

--- a/kyverno/base/policies/argocd/application-field-validation.yaml
+++ b/kyverno/base/policies/argocd/application-field-validation.yaml
@@ -1,0 +1,80 @@
+# https://main.kyverno.io/policies/argo/application-field-validation/application-field-validation/
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: application-field-validation
+  annotations:
+    policies.kyverno.io/title: Application Field Validation
+    policies.kyverno.io/category: Argo
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Application
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      This policy performs some best practices validation on Application fields.
+      project name should not be empty.
+      source.path should be specified and not the helm chart.
+      destination.name or destination.server should be specified but never both.
+      destination.namespace should match own namespace
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: empty-project
+      match:
+        any:
+          - resources:
+              kinds:
+                - Application
+      validate:
+        message: >-
+          `spec.project` should not be empty.
+        pattern:
+          - spec:
+              project: "?*"
+    - name: source-path-chart
+      match:
+        any:
+          - resources:
+              kinds:
+                - Application
+      validate:
+        message: >-
+          `spec.source.path` should be specified and not the helm chart.
+        anyPattern:
+          - spec:
+              source:
+                path: "?*"
+                X(chart):
+    - name: destination-server-name
+      match:
+        any:
+          - resources:
+              kinds:
+                - Application
+      validate:
+        message: >-
+          `spec.destination.server` OR `spec.destination.name` should be specified but never both.
+        anyPattern:
+          - spec:
+              destination:
+                server: "?*"
+                X(name):
+          - spec:
+              destination:
+                X(server):
+                name: "?*"
+    - name: destination-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - Application
+      validate:
+        message: >-
+          `spec.destination.namespace`should match application's own namespace.
+        pattern:
+          spec:
+            destination:
+              namespace: "{{request.object.namespace}}"

--- a/kyverno/base/policies/argocd/application-prevent-default-project.yaml
+++ b/kyverno/base/policies/argocd/application-prevent-default-project.yaml
@@ -1,0 +1,36 @@
+# https://main.kyverno.io/policies/argo/application-prevent-default-project/application-prevent-default-project/
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: application-prevent-default-project
+  annotations:
+    policies.kyverno.io/title: Prevent Use of Default Project
+    policies.kyverno.io/category: Argo
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Application
+    policies.kyverno.io/description: >-
+      Argocd project 'Default' is a privileges project.
+      This policy prevents the use of the default project in an Application.
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: default-project
+      match:
+        any:
+          - resources:
+              kinds:
+                - Application
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: NotEquals
+            value: DELETE
+      validate:
+        message: "The default project may not be used in an Application."
+        pattern:
+          spec:
+            project: "!default"

--- a/kyverno/base/policies/argocd/kustomization.yaml
+++ b/kyverno/base/policies/argocd/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - application-prevent-default-project.yaml

--- a/kyverno/base/policies/argocd/test/kyverno-test.yaml
+++ b/kyverno/base/policies/argocd/test/kyverno-test.yaml
@@ -1,0 +1,60 @@
+name: test-ingress-and-traefik-resources
+policies:
+  - ../application-field-validation.yaml
+  - ../application-prevent-default-project.yaml
+resources:
+  - test-application-prevent-default-project.yaml
+  - test-application-field-validation.yaml
+results:
+  # Test default-project
+  - policy: application-prevent-default-project
+    rule: default-project
+    kind: Application
+    resource: test-custom-project
+    result: pass
+  - policy: application-prevent-default-project
+    rule: default-project
+    kind: Application
+    resource: test-default-project
+    result: fail
+  - policy: application-prevent-default-project
+    rule: default-project
+    kind: Application
+    resource: test-missing-project-name
+    result: fail
+  # Test Application Fields validation
+  - policy: application-field-validation
+    rule: empty-project
+    kind: Application
+    resource: test-missing-project-name
+    result: fail
+  - policy: application-field-validation
+    rule: source-path-chart
+    kind: Application
+    resource: test-missing-source-path
+    result: fail
+  - policy: application-field-validation
+    rule: source-path-chart
+    kind: Application
+    resource: test-source-path-specified
+    result: pass
+  - policy: application-field-validation
+    rule: source-path-chart
+    kind: Application
+    resource: test-source-path-chart-specified
+    result: fail
+  - policy: application-field-validation
+    rule: destination-server-name
+    kind: Application
+    resource: test-missing-destination-server
+    result: fail
+  - policy: application-field-validation
+    rule: destination-namespace
+    kind: Application
+    resource: test-application-namespace-mismatch
+    result: fail
+  - policy: application-field-validation
+    rule: destination-namespace
+    kind: Application
+    resource: test-application-matching-namespace
+    result: pass

--- a/kyverno/base/policies/argocd/test/test-application-field-validation.yaml
+++ b/kyverno/base/policies/argocd/test/test-application-field-validation.yaml
@@ -1,0 +1,60 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-missing-project-name
+spec:
+  source:
+    repoURL: git@github.com:utilitywarehouse/something
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-missing-source-path
+spec:
+  source:
+    repoURL: git@github.com:utilitywarehouse/something
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-source-path-specified
+spec:
+  source:
+    repoURL: git@github.com:utilitywarehouse/something
+    path: dev
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-source-path-chart-specified
+spec:
+  source:
+    repoURL: git@github.com:utilitywarehouse/something
+    path: dev
+    chart: dev
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-missing-destination-server
+spec:
+  destination:
+    namespace: argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+namespace: blah
+metadata:
+  name: test-application-namespace-mismatch
+spec:
+  destination:
+    namespace: argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+namespace: argocd
+metadata:
+  name: test-application-matching-namespace
+spec:
+  destination:
+    namespace: argocd

--- a/kyverno/base/policies/argocd/test/test-application-prevent-default-project.yaml
+++ b/kyverno/base/policies/argocd/test/test-application-prevent-default-project.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-custom-project
+spec:
+  project: prj-sys-argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-default-project
+spec:
+  project: default
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-missing-project-name
+spec:
+  source:
+    repoURL: git@github.com:utilitywarehouse/something

--- a/kyverno/base/policies/kustomization.yaml
+++ b/kyverno/base/policies/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ingress/
-- namespaces/
-- pods/
-- serviceaccounts/
-- services/
+  - argocd/
+  - ingress/
+  - namespaces/
+  - pods/
+  - serviceaccounts/
+  - services/


### PR DESCRIPTION
creating 2 policy 
* application-field-validation
    * project name should not be empty.
    * source.path should be specified and not the helm chart.
    * destination.name or destination.server should be specified but never both.
    * destination.namespace should match own namespace
 * application-prevent-default-project