### PR TITLE
Use `warn` log level for metallb logs

### DIFF
--- a/metallb/namespaced/patches/controller.yaml
+++ b/metallb/namespaced/patches/controller.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
         - args:
             - --port=7472
-            - --log-level=info
+            - --log-level=warn
           env:
             - $patch: delete
               name: METALLB_ML_SECRET_NAME  # only required for L2/ARP mode

--- a/metallb/namespaced/patches/speaker.yaml
+++ b/metallb/namespaced/patches/speaker.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
         - args:
             - --port=7472
-            - --log-level=info
+            - --log-level=warn
           env:
             - $patch: delete
               name: METALLB_ML_BIND_ADDR


### PR DESCRIPTION
Info seems to be too noisy.