### PR TITLE
Update exteral-DNS to v0.13.1

### DIFF
--- a/external-dns/Makefile
+++ b/external-dns/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := get-upstream
 .PHONY: get-upstream
 
-# v0.12.2
-COMMIT_REF=4046257911958c1716f9a63ccf7846e2ee412ae6
+# v0.13.1
+COMMIT_REF=de3474436fd84b825dfcac9eb2f0d1f14804a5d3
 
 #VERSION=v0.12.2
 ## Using a later commit instead of the tagged version, because the release did not update the image.

--- a/external-dns/kustomization.yaml
+++ b/external-dns/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: k8s.gcr.io/external-dns/external-dns
-    newTag: v0.12.2
+  - name: registry.k8s.io/external-dns/external-dns
+    newTag: v0.13.1
 
 patchesStrategicMerge:
   - patches/deploy.yaml

--- a/external-dns/upstream/external-dns-deployment.yaml
+++ b/external-dns/upstream/external-dns-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: k8s.gcr.io/external-dns/external-dns
+          image: registry.k8s.io/external-dns/external-dns
           args:
             - --source=service
             - --source=ingress


### PR DESCRIPTION
Follow commit: https://github.com/kubernetes-sigs/external-dns/commit/de3474436fd84b825dfcac9eb2f0d1f14804a5d3