### PR TITLE
Fix typo in image and downgrade 1 version

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
+++ b/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
@@ -16,4 +16,4 @@ patchesStrategicMerge:
 # provided from upstream. Lets do it here:
 images:
   - name: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-    newTag: v1.18.1
+    newTag: v1.8.0


### PR DESCRIPTION
It looks like there is no image available for v1.8.1, so downgrading to v1.8.0