### PR TITLE
Fix external-dns image pull error - Use actual latest available

### DIFF
--- a/external-dns/kustomization.yaml
+++ b/external-dns/kustomization.yaml
@@ -2,13 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/kubernetes-sigs/external-dns/kustomize?ref=v0.13.3
-
-# Latest remote base change to image v0.13.2. Since there do not seem to be
-# manifest changes on the latest version (v0.13.3) let's patch it here.
-images:
-  - name: registry.k8s.io/external-dns/external-dns
-    newTag: v0.13.3
+  - https://github.com/kubernetes-sigs/external-dns/kustomize?ref=a37b59a414148b787868fb8d0d88ac731c9d63cf # v0.13.2
 
 patchesStrategicMerge:
   - patches/deploy.yaml


### PR DESCRIPTION
The last tag that is actually released and has an image available is v0.13.2. Even though we have to use a commit reference as the tag still deploys the previous version