### PR TITLE
Update ns owner label repo path in rule description

### DIFF
--- a/kyverno/policies/namespaces/require-ns-owner-label.yaml
+++ b/kyverno/policies/namespaces/require-ns-owner-label.yaml
@@ -21,7 +21,7 @@ spec:
     validate:
       message: >-
         The label `uw.systems/owner` is required. Check policy at
-        https://github.com/utilitywarehouse/system-manifests/tree/master/kyverno/base/policies/namespaces/require-ns-owner-label.yaml
+        https://github.com/utilitywarehouse/system-manifests/tree/master/kyverno/policies/namespaces/require-ns-owner-label.yaml
         for allowed label values.
       pattern:
         metadata:


### PR DESCRIPTION
Since we moved policies to a separate base we need to update instructions about where to add/manage teams for ns ownership.