### PR TITLE
Fix Kyverno webhooks and update deprecated fields

### DIFF
--- a/kyverno/deploy/deployment-arguments-patch.yaml
+++ b/kyverno/deploy/deployment-arguments-patch.yaml
@@ -3,14 +3,6 @@
 # -v=0 lowers logging verbisity as Kyverno tends to get chatty during background
 # operations and logs were dropper by the forwarders
 #
-# --autoUpdateWebhooks=false will configure Kyverno to create the default
-# webhook configurations that forwards admission requests for all resources
-# and with FailurePolicy set to Ignore:
-# https://kyverno.io/docs/installation/#webhooks
-# That will allow us to pass all admission requests when Kyverno is crashing,
-# and we should rely on background checks and alerts to catch potential
-# violations during Kyverno downtime.
-#
 # --admissionReports=false
 # --backgroundScan=false
 # If both backgroundScan and admissionReports are set to false the entire
@@ -32,7 +24,6 @@ spec:
       containers:
       - args:
         - -v=0
-        - --autoUpdateWebhooks=false
         - --admissionReports=false
         - --backgroundScan=false
         name: kyverno

--- a/kyverno/policies-audit-only/audit-only.yaml
+++ b/kyverno/policies-audit-only/audit-only.yaml
@@ -7,42 +7,42 @@ kind: ClusterPolicy
 metadata:
   name: disallow-default-tlsoptions
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-or-operator
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-wildcard-hostsni
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: external-dns-domain-label-length
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-ingress-host
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-ingressroute-host
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 # namespaces
 ---
@@ -51,21 +51,21 @@ kind: ClusterPolicy
 metadata:
   name: ensure-ns-name-label
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-delete-annotation-ns-label
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-ns-owner-label
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 # pods
 ---
@@ -74,98 +74,98 @@ kind: ClusterPolicy
 metadata:
   name: restrict-apparmor-profiles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: pod-capabilities
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-ipc-pods
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-network-pods
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: hostpath-vols
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-pid-pods
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-ports
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-scheduling-to-master-nodes
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-privileged-containers
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-privilege-escalation
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-proc-mount
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-seccomp
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-selinux
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-sysctls
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 # serviceaccounts
 ---
@@ -174,7 +174,7 @@ kind: ClusterPolicy
 metadata:
   name: vault-aws-role-arn
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 # services
 ---
@@ -183,35 +183,35 @@ kind: ClusterPolicy
 metadata:
   name: restrict-external-ips
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: no-localhost-service
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-load-balancer-ip
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-nodeport
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: mirror-name-length
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---
 # Middlewares
 apiVersion: kyverno.io/v1
@@ -219,5 +219,5 @@ kind: ClusterPolicy
 metadata:
   name: ensure-prisma-and-onprem-vpn-ip-whitelist
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
 ---

--- a/kyverno/policies/ingress/disallow-default-tsloptions.yaml
+++ b/kyverno/policies/ingress/disallow-default-tsloptions.yaml
@@ -14,7 +14,7 @@ metadata:
       creating the `default` TLSOption is a restricted operation. This policy ensures that
       only a cluster-admin can create the `default` TLSOption resource.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: disallow-default-tlsoptions

--- a/kyverno/policies/ingress/disallow-or-operator.yaml
+++ b/kyverno/policies/ingress/disallow-or-operator.yaml
@@ -11,7 +11,7 @@ metadata:
       Using || can allow you to subvert other restrictions and hijack traffic
       with non-specific rules that match generic paths or headers
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/ingress/disallow-wildcard-hostsni.yaml
+++ b/kyverno/policies/ingress/disallow-wildcard-hostsni.yaml
@@ -11,7 +11,7 @@ metadata:
       Prevent IngressRouteTCP from hijacking all traffic by preventing wildcard
       HostSNIs.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/ingress/external-dns-domain-label-length.yaml
+++ b/kyverno/policies/ingress/external-dns-domain-label-length.yaml
@@ -16,7 +16,7 @@ metadata:
       let's only check the one edited via external-DNS since the rest should be
       problematic regardless. 
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: domain-label-limit

--- a/kyverno/policies/ingress/require-ingress-host.yaml
+++ b/kyverno/policies/ingress/require-ingress-host.yaml
@@ -11,7 +11,7 @@ metadata:
       prevent ingresses from hijacking the default traefik route by requiring an
       explicit host value
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: require-ingress-host

--- a/kyverno/policies/ingress/require-ingressroute-host.yaml
+++ b/kyverno/policies/ingress/require-ingressroute-host.yaml
@@ -12,7 +12,7 @@ metadata:
       hostname as defined by RFC 1123. By requiring a Host rule, we prevent
       widespread hijacking by non-specific rules like PathPrefix(`/`).
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/ip-whitelist/ensure-prisma-and-onprem-vpn-ip-whitelist.yaml
+++ b/kyverno/policies/ip-whitelist/ensure-prisma-and-onprem-vpn-ip-whitelist.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: ensure-prisma-and-onprem-vpn-ip-whitelist
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   mutateExistingOnPolicyUpdate: true
   rules:
     - name: default

--- a/kyverno/policies/namespaces/ensure-ns-name-label.yaml
+++ b/kyverno/policies/namespaces/ensure-ns-name-label.yaml
@@ -11,7 +11,7 @@ metadata:
       Make sure every namespace has a `name` label that matches the actual
       namespace name.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: ensure-namespace-name-label

--- a/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
+++ b/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
@@ -11,7 +11,7 @@ metadata:
       Require namespaces to be annotated with 'uw.systems/delete-allowed: "true"'
       in order to allow deletion.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: require-annotation-before-deleting

--- a/kyverno/policies/namespaces/require-ns-owner-label.yaml
+++ b/kyverno/policies/namespaces/require-ns-owner-label.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Require all namespaces to mark ownership via uw.systems/owner label.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-for-namespace-owner-label

--- a/kyverno/policies/pods/AppArmor.yaml
+++ b/kyverno/policies/pods/AppArmor.yaml
@@ -14,8 +14,7 @@ metadata:
       overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: app-armor

--- a/kyverno/policies/pods/SELinux.yaml
+++ b/kyverno/policies/pods/SELinux.yaml
@@ -11,8 +11,7 @@ metadata:
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: selinux-type

--- a/kyverno/policies/pods/Seccomp.yaml
+++ b/kyverno/policies/pods/Seccomp.yaml
@@ -12,8 +12,7 @@ metadata:
       requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
       set to `RuntimeDefault` or `Localhost`.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: check-seccomp

--- a/kyverno/policies/pods/capabilities.yaml
+++ b/kyverno/policies/pods/capabilities.yaml
@@ -13,8 +13,7 @@ metadata:
       maps Kubernetes restricted pod security standard
       https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/hostIPC.yaml
+++ b/kyverno/policies/pods/hostIPC.yaml
@@ -10,8 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy ensures Pods do not use the host's IPC namespace
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/hostNetwork.yaml
+++ b/kyverno/policies/pods/hostNetwork.yaml
@@ -10,8 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy ensures Pods do not use the host's network interfaces.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/hostPID.yaml
+++ b/kyverno/policies/pods/hostPID.yaml
@@ -10,8 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy ensures Pods cannot use host's PID.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/hostPaths.yaml
+++ b/kyverno/policies/pods/hostPaths.yaml
@@ -12,8 +12,7 @@ metadata:
       hostPath volumes consume the underlying node's file system. Mounting host
       paths should be disabled by default, except for specific cases
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: restrict-hostpath-volumes

--- a/kyverno/policies/pods/hostPorts.yaml
+++ b/kyverno/policies/pods/hostPorts.yaml
@@ -13,8 +13,7 @@ metadata:
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: host-ports-none

--- a/kyverno/policies/pods/pod-node-restriction.yaml
+++ b/kyverno/policies/pods/pod-node-restriction.yaml
@@ -12,8 +12,7 @@ metadata:
       in a Pod spec which allows running on control plane nodes
       with the taint key `node-role.kubernetes.io/master`.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: restrict-scheduling-to-master

--- a/kyverno/policies/pods/privilege-escalation.yaml
+++ b/kyverno/policies/pods/privilege-escalation.yaml
@@ -12,8 +12,7 @@ metadata:
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/privileged.yaml
+++ b/kyverno/policies/pods/privileged.yaml
@@ -12,8 +12,7 @@ metadata:
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/pods/procMount.yaml
+++ b/kyverno/policies/pods/procMount.yaml
@@ -13,8 +13,7 @@ metadata:
       to deviate from the `Default` procMount requires setting a feature gate at the API
       server.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: check-proc-mount

--- a/kyverno/policies/pods/sysctls.yaml
+++ b/kyverno/policies/pods/sysctls.yaml
@@ -15,8 +15,7 @@ metadata:
       This policy ensures that only those "safe" subsets can be specified in
       a Pod.
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: check-sysctls

--- a/kyverno/policies/serviceaccounts/vault-annotation.yaml
+++ b/kyverno/policies/serviceaccounts/vault-annotation.yaml
@@ -11,8 +11,7 @@ metadata:
       Verify that `vault.uw.systems/aws-role` annotation contains a valid role
       arn
 spec:
-  validationFailureAction: enforce
-  failurePolicy: Ignore
+  validationFailureAction: Enforce
   background: false # Disable due to warning events noise.
   rules:
     - name: default

--- a/kyverno/policies/services/externalIPs.yaml
+++ b/kyverno/policies/services/externalIPs.yaml
@@ -14,7 +14,7 @@ metadata:
       See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: default

--- a/kyverno/policies/services/externalName.yaml
+++ b/kyverno/policies/services/externalName.yaml
@@ -12,7 +12,7 @@ metadata:
       vulnerabilities in some Ingress controllers. This policy audits Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false # Disable due to warning events noise: https://github.com/kyverno/kyverno/issues/4093
   rules:
     - name: default

--- a/kyverno/policies/services/loadBalancerIP.yaml
+++ b/kyverno/policies/services/loadBalancerIP.yaml
@@ -13,7 +13,7 @@ metadata:
       addresses, in order to avoid someone hijacking an external service IP
       from their service.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/services/nodePort.yaml
+++ b/kyverno/policies/services/nodePort.yaml
@@ -15,7 +15,7 @@ metadata:
       with additional upstream security checks. This policy validates that any new Services
       do not use the `NodePort` type.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default

--- a/kyverno/policies/services/semaphore-service-mirror-length.yaml
+++ b/kyverno/policies/services/semaphore-service-mirror-length.yaml
@@ -12,7 +12,7 @@ metadata:
       generate the mirrored service names, respecting the char limit of 63 for
       service names.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: default


### PR DESCRIPTION
- Remove autoUpdateWebhooks=false flag to allow Kyverno create and edit its webhooks and set different failurePolicy for resources according to policies
- Update `validationFailureAction` values to start with capital letters

tldr; Setting autoUpdateWebhooks=false will trigger Kyverno to use `failurePolicy: Ignore` in all the webhooks it creates which means that even if an admission request is denied by Kyverno the apiserver will still accept it. Changing that will make the webhook setup behave as expected, but will result in admissions being rejected in cases where Kyverno is down and cannot reply to apiserver.