### PR TITLE
Update coredns to v1.10.1

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -2,8 +2,8 @@
 .PHONY: get-upstream
 
 # https://github.com/coredns/deployment
-# 1.9.3
-COMMIT_REF=6135cc08f48270fc4f0cea141692db621e362c85
+# 1.9.4
+COMMIT_REF=128be7d6cea78fe335898fcaf87ffe85f1f2dc1c
 
 get-upstream:
 	curl -Ls \

--- a/coredns/kustomization.yaml
+++ b/coredns/kustomization.yaml
@@ -1,6 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+images:
+  - name: coredns/coredns
+    newTag: 1.10.1
+
 patches:
   - patch: |-
       - op: replace

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -80,6 +80,7 @@ metadata:
   labels:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: coredns
 spec:
   # replicas: not specified here:
   # 1. Default is 1.
@@ -91,10 +92,12 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
+      app.kubernetes.io/name: coredns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
+        app.kubernetes.io/name: coredns
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
@@ -114,7 +117,7 @@ spec:
              topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.9.3
+        image: coredns/coredns:1.9.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -180,9 +183,11 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: coredns
 spec:
   selector:
     k8s-app: kube-dns
+    app.kubernetes.io/name: coredns
   clusterIP: CLUSTER_DNS_IP
   ports:
   - name: dns


### PR DESCRIPTION
The `COMMIT_REF` in `Makefile` is set to v1.9.4 as this is the latest iteration of the upstream file available at the moment.
The image is patched to v1.10.1 in `kustomization.yaml`