### PR TITLE
Switch to kubernetes repo

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := get-upstream
 .PHONY: get-upstream
 
-# https://github.com/coredns/deployment
-# 1.9.4
-COMMIT_REF=128be7d6cea78fe335898fcaf87ffe85f1f2dc1c
+# https://github.com/kubernetes/kubernetes
+# 1.10.1
+COMMIT_REF=39e52449f9f40aa34037b81396a602803baf4991
 
 get-upstream:
 	curl -Ls \
-	 https://raw.githubusercontent.com/coredns/deployment/$(COMMIT_REF)/kubernetes/coredns.yaml.sed \
+	 https://raw.githubusercontent.com/kubernetes/kubernetes/$(COMMIT_REF)/cluster/addons/dns/coredns/coredns.yaml.sed \
 	 > upstream/coredns.yaml

--- a/coredns/kustomization.yaml
+++ b/coredns/kustomization.yaml
@@ -1,10 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-images:
-  - name: coredns/coredns
-    newTag: 1.10.1
-
 patches:
   - patch: |-
       - op: replace

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -1,33 +1,39 @@
+# Warning: This is a file generated from the base underscore template file: coredns.yaml.base
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
-  - apiGroups:
-    - ""
-    resources:
-    - endpoints
-    - services
-    - pods
-    - namespaces
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - discovery.k8s.io
-    resources:
-    - endpointslices
-    verbs:
-    - list
-    - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -36,6 +42,7 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
   name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,26 +58,30 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {
         errors
         health {
-          lameduck 5s
+            lameduck 5s
         }
         ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
+        kubernetes $DNS_DOMAIN in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
+        forward . /etc/resolv.conf {
+            max_concurrent 1000
         }
         cache 30
         loop
         reload
         loadbalance
-    }STUBDOMAINS
+    }
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -79,12 +90,14 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "CoreDNS"
-    app.kubernetes.io/name: coredns
 spec:
   # replicas: not specified here:
-  # 1. Default is 1.
-  # 2. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -92,36 +105,39 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      app.kubernetes.io/name: coredns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        app.kubernetes.io/name: coredns
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values: ["kube-dns"]
+              topologyKey: kubernetes.io/hostname
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
         kubernetes.io/os: linux
-      affinity:
-         podAntiAffinity:
-           requiredDuringSchedulingIgnoredDuringExecution:
-           - labelSelector:
-               matchExpressions:
-               - key: k8s-app
-                 operator: In
-                 values: ["kube-dns"]
-             topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.9.4
+        image: registry.k8s.io/coredns/coredns:v1.10.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 170Mi
+            memory: $DNS_MEMORY_LIMIT
           requests:
             cpu: 100m
             memory: 70Mi
@@ -140,14 +156,6 @@ spec:
         - containerPort: 9153
           name: metrics
           protocol: TCP
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_BIND_SERVICE
-            drop:
-            - all
-          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
@@ -162,6 +170,14 @@ spec:
             path: /ready
             port: 8181
             scheme: HTTP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:
         - name: config-volume
@@ -182,13 +198,12 @@ metadata:
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "CoreDNS"
-    app.kubernetes.io/name: coredns
 spec:
   selector:
     k8s-app: kube-dns
-    app.kubernetes.io/name: coredns
-  clusterIP: CLUSTER_DNS_IP
+  clusterIP: $DNS_SERVER_IP
   ports:
   - name: dns
     port: 53


### PR DESCRIPTION
The coredns/deployment repo has deprecated it's CoreDNS yaml template. Switching to kubeadm repo