### PR TITLE
Fix service mirror naming policy

### DIFF
--- a/kyverno/policies/services/semaphore-service-mirror-length.yaml
+++ b/kyverno/policies/services/semaphore-service-mirror-length.yaml
@@ -29,7 +29,7 @@ spec:
             operator: NotEquals
             value: DELETE
       validate:
-        message: "Mirror service controller should be able to generate 63 chars long mirrored names with prefixes [aws|gcp|merit]"
+        message: "Mirror service controller should be able to generate 63 chars long mirrored names with prefixes [aws|gcp|merit] and pattern <prefix>-<namespace>-73736d-<service-name>"
         deny:
           # The prefixes we use based on our clusters configuration are:
           # - aws
@@ -38,7 +38,11 @@ spec:
           # Since merit-<name> is the most expensive transformation we want this
           # rule to allow service names up to 63-6=57 chars long, in order to be
           # gracefully mirrored to all other clusters.
+          # The mirrored service name will follow the pattern:
+          # <prefix>-<namespace>-<separator>-<service-name>, where separator is
+          # 73736d
           conditions:
-            - key: "{{ request.object.metadata.name | length(@) }}"
+            - key: >-
+               {{ join('-', [request.object.metadata.namespace, '73736d', request.object.metadata.name]) | length(@) }}
               operator: GreaterThanOrEquals
               value: 57 # 63 - 6 (merit-)

--- a/kyverno/policies/services/test/kyverno-test.yaml
+++ b/kyverno/policies/services/test/kyverno-test.yaml
@@ -57,3 +57,8 @@ results:
     resource: test-very-very-very-very-very-very-very-very-long-name-svc
     kind: Service
     result: fail
+  - policy: mirror-name-length
+    rule: default
+    resource: broadband-product-availability-app
+    kind: Service
+    result: fail

--- a/kyverno/policies/services/test/test-semaphore-service-mirror-length.yaml
+++ b/kyverno/policies/services/test/test-semaphore-service-mirror-length.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-valid-length
+  namespace: test
   labels:
     uw.systems/mirror: "true"
 ---
@@ -9,5 +10,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-very-very-very-very-very-very-very-very-long-name-svc # 59 chars
+  namespace: test
+  labels:
+    uw.systems/mirror: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: broadband-product-availability-app
+  namespace: telecom-fixed-line
   labels:
     uw.systems/mirror: "true"


### PR DESCRIPTION
We need to include namespace and separator into the rule to calculate the maximum length allowed for a mirrored service name