### PR TITLE
Update control plane components tolerations

### DIFF
--- a/aws-ebs-csi-driver/controller-patch.yaml
+++ b/aws-ebs-csi-driver/controller-patch.yaml
@@ -9,6 +9,8 @@ spec:
         # Mark the pod so it can be scheduled on master nodes.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Deploy on masters to be able to get credentials/permissions from the node
       nodeSelector:
         role: master

--- a/etcd-backup/base/etcd-backup.yaml
+++ b/etcd-backup/base/etcd-backup.yaml
@@ -62,6 +62,8 @@ spec:
             # Mark the pod so it can be scheduled on master nodes.
             - key: node-role.kubernetes.io/master
               effect: NoSchedule
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
           nodeSelector:
             role: master
           volumes:

--- a/gcp-compute-persistent-disk-csi-driver/csi-gce-pd-controller-patch.yaml
+++ b/gcp-compute-persistent-disk-csi-driver/csi-gce-pd-controller-patch.yaml
@@ -12,6 +12,8 @@ spec:
         # Mark the pod so it can be scheduled on master nodes.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Deploy on masters to be able to get credentials/permissions from the node
       nodeSelector:
         role: master

--- a/kyverno/deploy/deployment-master-schedule-patch.yaml
+++ b/kyverno/deploy/deployment-master-schedule-patch.yaml
@@ -11,5 +11,7 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       nodeSelector:
         role: master

--- a/kyverno/policies/pods/pod-node-restriction.yaml
+++ b/kyverno/policies/pods/pod-node-restriction.yaml
@@ -33,3 +33,21 @@ spec:
         spec:
           =(tolerations):
             - key: "!node-role.kubernetes.io/master"
+  - name: restrict-controlplane-scheduling-control-plane
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - "sys-*"
+    validate:
+      message: Pods may not use tolerations which schedule on control plane nodes.
+      pattern:
+        spec:
+          =(tolerations):
+            - key: "!node-role.kubernetes.io/control-plane"

--- a/node-exporter/namespaced/daemonset.yaml
+++ b/node-exporter/namespaced/daemonset.yaml
@@ -20,6 +20,8 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
         - image: quay.io/prometheus/node-exporter:v1.6.0
           name: node-exporter

--- a/trident/namespaced/trident-deployment-patch.yaml
+++ b/trident/namespaced/trident-deployment-patch.yaml
@@ -13,6 +13,8 @@ spec:
         # volumes
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       nodeSelector:
         role: master
       volumes:


### PR DESCRIPTION
Allow workloads we schedule on master nodes to tolerate: node-role.kubernetes.io/control-plane taint