### PR TITLE
cloud-provider-gcp: Initial deploy of kustomize base

### DIFF
--- a/cloud-provider-gcp/Makefile
+++ b/cloud-provider-gcp/Makefile
@@ -1,0 +1,18 @@
+.PHONY: update
+CCM_VERSION:=v27.1.5
+# This is a temporary workaround and should be replaced by the above variable
+# once this issue is resolved:
+# https://github.com/kubernetes/cloud-provider-gcp/issues/289
+# It looks like they recently start to push images under
+# registry.k8s.io/cloud-provider-gcp/cloud-controller-manager but tagging is
+# wrong atm and points to a non-existent repo tag.
+CCM_IMAGE_VERSION:= v26.2.4
+
+update:
+	# This fetches  an example manifest from upstream repo used to test on
+	# kOps. Author of the change claims that this is to be used to test
+	# production scenariosn, so it could be a valid base for us:
+	# https://github.com/kubernetes/cloud-provider-gcp/commit/79d1462d8c05e14d98c44d03067bdb80fb6cd9df
+	curl -s https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/ccm/${CCM_VERSION}/deploy/packages/default/manifest.yaml > upstream.yaml
+	# We also need to update the image as the upstream points to `latest`
+	sed -i "s/newTag:.*/newTag: ${CCM_IMAGE_VERSION}/g" kustomization.yaml

--- a/cloud-provider-gcp/args-patch.yaml
+++ b/cloud-provider-gcp/args-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: cloud-controller-manager
+          args:
+            - /cloud-controller-manager
+            - --allocate-node-cidrs=true
+            - --cloud-config=/etc/kubernetes/config/cloud_provider/cloud.conf
+            - --cloud-provider=gce
+            - --cluster-cidr=10.4.0.0/16
+            - --configure-cloud-routes=false
+            - --controllers=*,-nodeipam,-route,-gkenetworkparamset # Disable controllers we do not need due to calico
+            - --enable-leader-migration=true
+            - --v=2

--- a/cloud-provider-gcp/image-patch.yaml
+++ b/cloud-provider-gcp/image-patch.yaml
@@ -1,0 +1,13 @@
+# Generic patch for the image. Version is updated via sed after running
+# make update via configuration in kustomization.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: cloud-controller-manager
+          image: cloud-controller-manager

--- a/cloud-provider-gcp/kustomization.yaml
+++ b/cloud-provider-gcp/kustomization.yaml
@@ -1,0 +1,86 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - upstream.yaml
+
+patches:
+  - path: args-patch.yaml
+  - path: image-patch.yaml
+  - path: volume-patch.yaml
+  # Deploy on control-plane nodes. Upstream sets this to null which makes
+  # apiserver to moan. Also, we want to schedule pods there before waiting for
+  # our labeller to mark the node as control-plane, thus we can use role=master
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/nodeSelector
+        value:
+          role: "master"
+    target:
+      kind: DaemonSet
+      name: cloud-controller-manager
+      namespace: kube-system
+  # Temporary - to be deleted after migration. Require the node to not be
+  # marked as kube-controller-manager-mode=enable-leader-migration
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/-
+        value:
+          key: kube-controller-manager-mode
+          operator: NotIn
+          values:
+            - "enable-leader-migration"
+    target:
+      kind: DaemonSet
+      name: cloud-controller-manager
+      namespace: kube-system
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/1/matchExpressions/-
+        value:
+          key: kube-controller-manager-mode
+          operator: NotIn
+          values:
+            - "enable-leader-migration"
+    target:
+      kind: DaemonSet
+      name: cloud-controller-manager
+      namespace: kube-system
+  # Required during migration
+  # https://kubernetes.io/docs/tasks/administer-cluster/controller-manager-leader-migration/#grant-access-to-migration-lease
+  - patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          resourceNames:
+          - cloud-provider-extraction-migration
+          verbs:
+          - create
+          - list
+          - get
+          - update
+    target:
+      kind: Role
+      name: system::leader-locking-cloud-controller-manager
+      namespace: kube-system
+  # Bind cloud-controller-manager to cloud-node-controller to be able to manage
+  # nodes
+  - patch: |-
+      - op: add
+        path: /subjects/-
+        value:
+          kind: ServiceAccount
+          name: cloud-controller-manager
+          namespace: kube-system
+    target:
+      kind: ClusterRoleBinding
+      name: system:controller:cloud-node-controller
+
+images:
+  - name: cloud-controller-manager
+    newName: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
+    newTag: v26.2.4

--- a/cloud-provider-gcp/upstream.yaml
+++ b/cloud-provider-gcp/upstream.yaml
@@ -1,0 +1,356 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    component: cloud-controller-manager
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+spec:
+  selector:
+    matchLabels:
+      component: cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: cloud-controller-manager
+    spec:
+      nodeSelector: null
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+      - name: cloud-controller-manager
+        image: k8scloudprovidergcp/cloud-controller-manager:latest
+        imagePullPolicy: IfNotPresent
+        # ko puts it somewhere else... command: ['/usr/local/bin/cloud-controller-manager']
+        args: [] # args must be replaced by tooling
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10258
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          requests:
+            cpu: "200m"
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/cloud-node-controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cloud-controller-manager
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - update
+  - patch # until #393 lands
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system::leader-locking-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cloud-controller-manager
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:cloud-node-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - list
+  - update
+  - delete
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - list
+  - delete
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/cloud-node-controller-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system::leader-locking-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system::leader-locking-cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  apiGroup: ""
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:controller:cloud-node-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:cloud-node-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
+  namespace: kube-system
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/pvl-controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:pvl-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - list
+  - watch

--- a/cloud-provider-gcp/volume-patch.yaml
+++ b/cloud-provider-gcp/volume-patch.yaml
@@ -1,0 +1,20 @@
+# Patch cloud config with the location we set it via our ignition
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-controller-manager
+        volumeMounts:
+        - mountPath: /etc/kubernetes/config/cloud_provider/cloud.conf
+          name: cloudconfig
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/config/cloud_provider/cloud.conf
+          type: ""
+        name: cloudconfig


### PR DESCRIPTION
This is creating a target to fetch from an upstream example kops deployment and patches arguments, volumes and image to give us a base to deploy cloud-provider-gcp. For some reason upstream manifests require hostNetwork, which is not a kops things but seems to be involved in all their manifest templates.