### PR TITLE
Update vault init container patch

### DIFF
--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -234,7 +234,7 @@ spec:
                   - name: vault-tls
                     mountPath: /etc/tls
             containers:
-              - name: "etcd-bucket-push"
+              - (name): "*"
                 env:
                   - name: AWS_SHARED_CREDENTIALS_FILE
                     value: "/etc/aws/credentials"


### PR DESCRIPTION
Changing the patch of the `etcd-bucket-push` container to the patch of
any existing containers to avoid errors in deployments that don't have
`etcd-bucket-push` container and make it work with any other containers
that need access to AWS.