### PR TITLE
Affinity rule for cloud-provider-aws migration

### DIFF
--- a/cloud-provider-aws/affinity-patch.yaml
+++ b/cloud-provider-aws/affinity-patch.yaml
@@ -1,0 +1,19 @@
+# To help when migrating from kube-controller-manager. Shall be removed after
+# migration is completed in all envs
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kube-controller-manager-mode
+                operator: NotIn
+                values:
+                  - "enable-leader-migration"

--- a/cloud-provider-aws/kustomization.yaml
+++ b/cloud-provider-aws/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - upstream.yaml
 
 patches:
+  - path: affinity-patch.yaml
   - path: args-patch.yaml


### PR DESCRIPTION
Add a rule that will prevent the controller from being scheduled on nodes labelled to still run the old kube-controller manager with cloud specific features