### PR TITLE
Kyverno: Allow policies to set failurePolicy, keep all at Ignore

### DIFF
--- a/kyverno/deploy/deployment-arguments-patch.yaml
+++ b/kyverno/deploy/deployment-arguments-patch.yaml
@@ -24,7 +24,6 @@ spec:
       containers:
       - args:
         - -v=0
-        - --forceFailurePolicyIgnore=true
         - --admissionReports=false
         - --backgroundScan=false
         name: kyverno

--- a/kyverno/policies/ingress/disallow-default-tsloptions.yaml
+++ b/kyverno/policies/ingress/disallow-default-tsloptions.yaml
@@ -15,6 +15,7 @@ metadata:
       only a cluster-admin can create the `default` TLSOption resource.
 spec:
   validationFailureAction: Enforce
+  failurePolicy: Ignore
   background: false
   rules:
   - name: disallow-default-tlsoptions

--- a/kyverno/policies/ingress/disallow-or-operator.yaml
+++ b/kyverno/policies/ingress/disallow-or-operator.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/ingress/disallow-wildcard-hostsni.yaml
+++ b/kyverno/policies/ingress/disallow-wildcard-hostsni.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/ingress/external-dns-domain-label-length.yaml
+++ b/kyverno/policies/ingress/external-dns-domain-label-length.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: domain-label-limit
       # To be patched in environments that do not use infra as prefix

--- a/kyverno/policies/ingress/require-ingress-host.yaml
+++ b/kyverno/policies/ingress/require-ingress-host.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
   - name: require-ingress-host
     match:

--- a/kyverno/policies/ingress/require-ingressroute-host.yaml
+++ b/kyverno/policies/ingress/require-ingressroute-host.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/ip-whitelist/ensure-prisma-and-onprem-vpn-ip-whitelist.yaml
+++ b/kyverno/policies/ip-whitelist/ensure-prisma-and-onprem-vpn-ip-whitelist.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ensure-prisma-and-onprem-vpn-ip-whitelist
 spec:
   validationFailureAction: Enforce
+  failurePolicy: Ignore
   mutateExistingOnPolicyUpdate: true
   rules:
     - name: default

--- a/kyverno/policies/namespaces/ensure-ns-name-label.yaml
+++ b/kyverno/policies/namespaces/ensure-ns-name-label.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
   - name: ensure-namespace-name-label
     match:

--- a/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
+++ b/kyverno/policies/namespaces/require-annotation-to-delete-ns.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: false
+  failurePolicy: Ignore
   rules:
   - name: require-annotation-before-deleting
     match:

--- a/kyverno/policies/namespaces/require-ns-owner-label.yaml
+++ b/kyverno/policies/namespaces/require-ns-owner-label.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
   - name: check-for-namespace-owner-label
     match:

--- a/kyverno/policies/pods/AppArmor.yaml
+++ b/kyverno/policies/pods/AppArmor.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: app-armor
       match:

--- a/kyverno/policies/pods/SELinux.yaml
+++ b/kyverno/policies/pods/SELinux.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: selinux-type
       match:

--- a/kyverno/policies/pods/Seccomp.yaml
+++ b/kyverno/policies/pods/Seccomp.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: check-seccomp
       match:

--- a/kyverno/policies/pods/capabilities.yaml
+++ b/kyverno/policies/pods/capabilities.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/hostIPC.yaml
+++ b/kyverno/policies/pods/hostIPC.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/hostNetwork.yaml
+++ b/kyverno/policies/pods/hostNetwork.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/hostPID.yaml
+++ b/kyverno/policies/pods/hostPID.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/hostPaths.yaml
+++ b/kyverno/policies/pods/hostPaths.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: restrict-hostpath-volumes
       match:

--- a/kyverno/policies/pods/hostPorts.yaml
+++ b/kyverno/policies/pods/hostPorts.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: host-ports-none
       match:

--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: inject-vault-credentials-agent-aws
       context:

--- a/kyverno/policies/pods/pod-node-restriction.yaml
+++ b/kyverno/policies/pods/pod-node-restriction.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
   - name: restrict-scheduling-to-master
     match:

--- a/kyverno/policies/pods/privilege-escalation.yaml
+++ b/kyverno/policies/pods/privilege-escalation.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/privileged.yaml
+++ b/kyverno/policies/pods/privileged.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/pods/procMount.yaml
+++ b/kyverno/policies/pods/procMount.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: check-proc-mount
       match:

--- a/kyverno/policies/pods/sysctls.yaml
+++ b/kyverno/policies/pods/sysctls.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: check-sysctls
       match:

--- a/kyverno/policies/serviceaccounts/vault-annotation.yaml
+++ b/kyverno/policies/serviceaccounts/vault-annotation.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: false # Disable due to warning events noise.
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/services/externalIPs.yaml
+++ b/kyverno/policies/services/externalIPs.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
   - name: default
     match:

--- a/kyverno/policies/services/externalName.yaml
+++ b/kyverno/policies/services/externalName.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: false # Disable due to warning events noise: https://github.com/kyverno/kyverno/issues/4093
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/services/loadBalancerIP.yaml
+++ b/kyverno/policies/services/loadBalancerIP.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/services/nodePort.yaml
+++ b/kyverno/policies/services/nodePort.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:

--- a/kyverno/policies/services/semaphore-service-mirror-length.yaml
+++ b/kyverno/policies/services/semaphore-service-mirror-length.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  failurePolicy: Ignore
   rules:
     - name: default
       match:


### PR DESCRIPTION
We should allow policies to set their desired failurePolicy and not hardcode them all to Ignore. This removes the respective flag from kyverno and sets all existing policies from this base to Ignore in order to preserve functionality (default value is Fail).