### PR TITLE
Add manifest for OpsLevel alias injector

### DIFF
--- a/kyverno/policies/kustomization.yaml
+++ b/kyverno/policies/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - pods/
   - serviceaccounts/
   - services/
+  - opslevel-alias-injector/

--- a/kyverno/policies/opslevel-alias-injector/README.md
+++ b/kyverno/policies/opslevel-alias-injector/README.md
@@ -1,0 +1,14 @@
+# OpsLevel Alias Injector
+
+This is a [mutating cluster
+policy](https://kyverno.io/docs/writing-policies/mutate/) to inject the [unique
+service
+identifier](https://linear.app/utilitywarehouse/issue/DENA-149/allow-associating-the-kubernetes-resources-with-opslevel-id)
+alias we generate for each service in OpsLevel, it injects:
+
+  - An annotation: `app.uw.systems/opslevel-service-alias`
+  - An environment variable: `OPSLEVEL_SERVICE_ALIAS` (inside any container in
+    the spec)
+
+Into the spec for Deployments, CronJobs, and StatefulSets so that they are
+available to pods created under these replica controllers.

--- a/kyverno/policies/opslevel-alias-injector/kustomization.yaml
+++ b/kyverno/policies/opslevel-alias-injector/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- opslevel-alias-injector.yaml

--- a/kyverno/policies/opslevel-alias-injector/opslevel-alias-injector.yaml
+++ b/kyverno/policies/opslevel-alias-injector/opslevel-alias-injector.yaml
@@ -1,0 +1,72 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: opslevel-alias-injector
+spec:
+  rules:
+  - name: inject-opslevel-alias-for-deployments
+    match:
+      all:
+      - resources:
+          kinds:
+          - Deployment
+          namespaces:
+            - dev-enablement
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                app.uw.systems/opslevel-service-alias: "k8s:deployment:{{ request.namespace }}-{{ request.object.metadata.name }}"
+            spec:
+              containers:
+                # conditional anchor, only add the value if not present
+                - (name): "*"
+                  env:
+                    - name: OPSLEVEL_SERVICE_ALIAS
+                      value: "k8s:deployment:{{ request.namespace }}-{{ request.object.metadata.name }}"
+  - name: inject-opslevel-alias-for-statefulsets
+    match:
+      all:
+      - resources:
+          kinds:
+          - StatefulSet
+          namespaces:
+            - dev-enablement
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                app.uw.systems/opslevel-service-alias: "k8s:sts:{{ request.namespace }}-{{ request.object.metadata.name }}"
+            spec:
+              containers:
+                - (name): "*"
+                  env:
+                    - name: OPSLEVEL_SERVICE_ALIAS
+                      value: "k8s:sts:{{ request.namespace }}-{{ request.object.metadata.name }}"
+  - name: inject-opslevel-alias-for-cronjobs
+    match:
+      all:
+      - resources:
+          kinds:
+          - CronJob
+          namespaces:
+            - dev-enablement
+    mutate:
+      patchStrategicMerge:
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  annotations:
+                    app.uw.systems/opslevel-service-alias: "k8s:cronjob:{{ request.namespace }}-{{ request.object.metadata.name }}"
+                spec:
+                  containers:
+                    - (name): "*"
+                      env:
+                        - name: OPSLEVEL_SERVICE_ALIAS
+                          value: "k8s:cronjob:{{ request.namespace }}-{{ request.object.metadata.name }}"

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: in-another-namespace
+  namespace: not-dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-data.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: with-data
+  namespace: dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:dev-enablement-with-data
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest
+              env:
+                - name: OPSLEVEL_SERVICE_ALIAS
+                  value: k8s:cronjob:dev-enablement-with-data

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-different-name-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-different-name-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:dev-enablement-with-different-name
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest
+              env:
+                - name: OPSLEVEL_SERVICE_ALIAS
+                  value: k8s:cronjob:dev-enablement-with-different-name

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-different-name.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-with-different-name.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:dev-enablement-some-other-name
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest
+              env:
+                - name: OPSLEVEL_SERVICE_ALIAS
+                  value: k8s:cronjob:dev-enablement-some-other-name

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-without-data-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-without-data-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            foo.example/some-other-annotation: value
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:dev-enablement-without-data
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest
+              env:
+                - name: SOME_OTHER_VAR
+                  value: ok
+                - name: OPSLEVEL_SERVICE_ALIAS
+                  value: k8s:cronjob:dev-enablement-without-data

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-without-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-without-data.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            foo.example/some-other-annotation: value
+        spec:
+          containers:
+            - name: job-container
+              image: my-job-image:latest
+              env:
+                - name: SOME_OTHER_VAR
+                  value: ok

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: in-another-namespace
+  namespace: not-dev-enablement
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-with-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-with-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: with-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:dev-enablement-with-data"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-with-data"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-with-different-name-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-with-different-name-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:dev-enablement-with-different-name"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-with-different-name"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-with-different-name.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-with-different-name.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:dev-enablement-some-other-name"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-some-other-name"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-multiple-containers-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-multiple-containers-patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: without-data-multiple-containers
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:dev-enablement-without-data-multiple-containers"
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-without-data-multiple-containers"
+        - name: other-image
+          image: other-image:latest
+          env:
+            - name: SOME_VAR
+              value: ok
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-without-data-multiple-containers"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-multiple-containers.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-multiple-containers.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: without-data-multiple-containers
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok
+        - name: other-image
+          image: other-image:latest
+          env:
+            - name: SOME_VAR
+              value: ok

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:dev-enablement-without-data"
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:dev-enablement-without-data"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-without-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok

--- a/kyverno/policies/opslevel-alias-injector/tests/kyverno-test.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/kyverno-test.yaml
@@ -1,0 +1,94 @@
+name: opslevel_data_injection 
+policies:
+  - ../opslevel-alias-injector.yaml
+variables: variables.yaml
+resources:
+  - deployment-without-data.yaml
+  - deployment-without-data-multiple-containers.yaml
+  - deployment-with-different-name.yaml
+  - deployment-with-data.yaml
+  - deployment-in-other-namespace.yaml
+  - statefulset-without-data.yaml
+  - statefulset-with-different-name.yaml
+  - statefulset-with-data.yaml
+  - statefulset-in-other-namespace.yaml
+  - cronjob-without-data.yaml
+  - cronjob-with-different-name.yaml
+  - cronjob-with-data.yaml
+  - cronjob-in-other-namespace.yaml
+results:
+  # Deployment tests
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-deployments
+    resource: without-data
+    patchedResource: deployment-without-data-patch.yaml
+    kind: Deployment
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-deployments
+    resource: without-data-multiple-containers
+    patchedResource: deployment-without-data-multiple-containers-patch.yaml
+    kind: Deployment
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-deployments
+    resource: with-different-name
+    patchedResource: deployment-with-different-name-patch.yaml
+    kind: Deployment
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-deployments
+    resource: with-data
+    kind: Deployment
+    result: skip
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-deployments
+    resource: in-another-namespace
+    kind: Deployment
+    result: skip
+  # StatefulSet tests
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-statefulsets
+    resource: without-data
+    patchedResource: statefulset-without-data-patch.yaml
+    kind: StatefulSet
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-statefulsets
+    resource: with-different-name
+    patchedResource: statefulset-with-different-name-patch.yaml
+    kind: StatefulSet
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-statefulsets
+    resource: with-data
+    kind: StatefulSet
+    result: skip
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-statefulsets
+    resource: in-another-namespace
+    kind: StatefulSet
+    result: skip
+  # CronJob tests
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-cronjobs
+    resource: without-data
+    patchedResource: cronjob-without-data-patch.yaml
+    kind: CronJob
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-cronjobs
+    resource: with-different-name
+    patchedResource: cronjob-with-different-name-patch.yaml
+    kind: CronJob
+    result: pass
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-cronjobs
+    resource: with-data
+    kind: CronJob
+    result: skip
+  - policy: opslevel-alias-injector
+    rule: inject-opslevel-alias-for-cronjobs
+    resource: in-another-namespace
+    kind: CronJob
+    result: skip

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: in-another-namespace
+  namespace: not-dev-enablement
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: with-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:sts:dev-enablement-with-data"
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:sts:dev-enablement-with-data"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-different-name-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-different-name-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:sts:dev-enablement-with-different-name"
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:sts:dev-enablement-with-different-name"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-different-name.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-with-different-name.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: with-different-name
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:sts:dev-enablement-some-other-name"
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:sts:dev-enablement-some-other-name"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-without-data-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-without-data-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:sts:dev-enablement-without-data"
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:sts:dev-enablement-without-data"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-without-data.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-without-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: without-data
+  namespace: dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        foo.example/some-other-annotation: value
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: SOME_OTHER_VAR
+              value: ok

--- a/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
@@ -1,0 +1,2 @@
+globalValues:
+  request.namespace: dev-enablement


### PR DESCRIPTION
See README for details on what this policy does. For the moment this policy will only act under the `dev-enablement` namespace just to see how things go.

This is being added here, rather than in our mono-repo to keep all the kyverno policies in one place, so we don't have to clone another repo to build these manifests

I've already deployed a version of this in `dev-aws` (see [1],[2] I'll remove this shortly) which after updating a deployment by just adding then removing a new annotation, creates pods having (note: I've since changed the name of the annotation/env var so it's different to what's in this diff):

    $ kubectl --context dev-aws --namespace dev-enablement get pod --output json opslevel-k8s-deployer-6fb76f676b-86zss | jq '.metadata.annotations."app.uw.systems/opslevel-service"'
    "k8s:deployment:dev-enablement-opslevel-k8s-deployer"
    $ kubectl --context dev-aws --namespace dev-enablement get pod --output json opslevel-k8s-deployer-6fb76f676b-86zss | jq '.spec.containers[].env[] | select(.name=="OPSLEVEL_SERVICE")'
    {
      "name": "OPSLEVEL_SERVICE",
      "value": "k8s:deployment:dev-enablement-opslevel-k8s-deployer"
    }

[1] https://github.com/utilitywarehouse/kubernetes-manifests/pull/74533
[2] https://github.com/utilitywarehouse/kubernetes-manifests/pull/74538

Ticket: DENA-149