### PR TITLE
DENA-149 include all namespaces for opslevel injector

### DIFF
--- a/kyverno/policies/opslevel-alias-injector/opslevel-alias-injector.yaml
+++ b/kyverno/policies/opslevel-alias-injector/opslevel-alias-injector.yaml
@@ -10,8 +10,6 @@ spec:
       - resources:
           kinds:
           - Deployment
-          namespaces:
-            - dev-enablement
     mutate:
       patchStrategicMerge:
         spec:
@@ -32,8 +30,6 @@ spec:
       - resources:
           kinds:
           - StatefulSet
-          namespaces:
-            - dev-enablement
     mutate:
       patchStrategicMerge:
         spec:
@@ -53,8 +49,6 @@ spec:
       - resources:
           kinds:
           - CronJob
-          namespaces:
-            - dev-enablement
     mutate:
       patchStrategicMerge:
         spec:

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace-patch.yaml
@@ -8,7 +8,13 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:not-dev-enablement-in-another-namespace
         spec:
           containers:
             - name: job-container
               image: my-job-image:latest
+              env:
+                - name: OPSLEVEL_SERVICE_ALIAS
+                  value: k8s:cronjob:not-dev-enablement-in-another-namespace

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace-patch.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   schedule: "* * * * *"
   jobTemplate:
@@ -10,11 +10,11 @@ spec:
       template:
         metadata:
           annotations:
-            app.uw.systems/opslevel-service-alias: k8s:cronjob:not-dev-enablement-in-another-namespace
+            app.uw.systems/opslevel-service-alias: k8s:cronjob:kube-system-in-another-namespace
         spec:
           containers:
             - name: job-container
               image: my-job-image:latest
               env:
                 - name: OPSLEVEL_SERVICE_ALIAS
-                  value: k8s:cronjob:not-dev-enablement-in-another-namespace
+                  value: k8s:cronjob:kube-system-in-another-namespace

--- a/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/cronjob-in-other-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   schedule: "* * * * *"
   jobTemplate:

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace-patch.yaml
@@ -2,17 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   replicas: 1
   template:
     metadata:
       annotations:
-        app.uw.systems/opslevel-service-alias: "k8s:deployment:not-dev-enablement-in-another-namespace"
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:kube-system-in-another-namespace"
     spec:
       containers:
         - name: nginx
           image: nginx:latest
           env:
             - name: OPSLEVEL_SERVICE_ALIAS
-              value: "k8s:deployment:not-dev-enablement-in-another-namespace"
+              value: "k8s:deployment:kube-system-in-another-namespace"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: in-another-namespace
+  namespace: not-dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:deployment:not-dev-enablement-in-another-namespace"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:deployment:not-dev-enablement-in-another-namespace"

--- a/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/deployment-in-other-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   replicas: 1
   template:

--- a/kyverno/policies/opslevel-alias-injector/tests/kyverno-test.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/kyverno-test.yaml
@@ -45,7 +45,8 @@ results:
     rule: inject-opslevel-alias-for-deployments
     resource: in-another-namespace
     kind: Deployment
-    result: skip
+    patchedResource: deployment-in-other-namespace-patch.yaml
+    result: pass
   # StatefulSet tests
   - policy: opslevel-alias-injector
     rule: inject-opslevel-alias-for-statefulsets
@@ -68,7 +69,8 @@ results:
     rule: inject-opslevel-alias-for-statefulsets
     resource: in-another-namespace
     kind: StatefulSet
-    result: skip
+    patchedResource: statefulset-in-other-namespace-patch.yaml
+    result: pass
   # CronJob tests
   - policy: opslevel-alias-injector
     rule: inject-opslevel-alias-for-cronjobs
@@ -91,4 +93,5 @@ results:
     rule: inject-opslevel-alias-for-cronjobs
     resource: in-another-namespace
     kind: CronJob
-    result: skip
+    patchedResource: cronjob-in-other-namespace-patch.yaml
+    result: pass

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace-patch.yaml
@@ -2,17 +2,17 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   replicas: 1
   template:
     metadata:
       annotations:
-        app.uw.systems/opslevel-service-alias: "k8s:sts:not-dev-enablement-in-another-namespace"
+        app.uw.systems/opslevel-service-alias: "k8s:sts:kube-system-in-another-namespace"
     spec:
       containers:
         - name: elasticsearch
           image: elasticsearch:latest
           env:
             - name: OPSLEVEL_SERVICE_ALIAS
-              value: "k8s:sts:not-dev-enablement-in-another-namespace"
+              value: "k8s:sts:kube-system-in-another-namespace"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace-patch.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: in-another-namespace
+  namespace: not-dev-enablement
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        app.uw.systems/opslevel-service-alias: "k8s:sts:not-dev-enablement-in-another-namespace"
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:latest
+          env:
+            - name: OPSLEVEL_SERVICE_ALIAS
+              value: "k8s:sts:not-dev-enablement-in-another-namespace"

--- a/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/statefulset-in-other-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: in-another-namespace
-  namespace: not-dev-enablement
+  namespace: kube-system
 spec:
   replicas: 1
   template:

--- a/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
@@ -1,2 +1,8 @@
 globalValues:
   request.namespace: dev-enablement
+policies:
+  - name: opslevel-alias-injector
+    resources:
+      - name: in-another-namespace
+        values:
+          request.namespace: not-dev-enablement

--- a/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
+++ b/kyverno/policies/opslevel-alias-injector/tests/variables.yaml
@@ -5,4 +5,4 @@ policies:
     resources:
       - name: in-another-namespace
         values:
-          request.namespace: not-dev-enablement
+          request.namespace: kube-system


### PR DESCRIPTION
- Remove namespace filter for Opslevel alias injector

    This is running successfully under the `dev-enablement` namespace in
    prod and dev so I'm looking to roll out it's usage across all namespaces

- Update other namespace name in tests

    Rename this to an actual in-use namespace so the tests are a bit more
    demonstrable

Ticket:  DENA-149