### PR TITLE
kube-state-metrics: allow app.uw.systems/owner and app.uw.systems/system

### DIFF
--- a/kube-state-metrics/namespaced/patch.yaml
+++ b/kube-state-metrics/namespaced/patch.yaml
@@ -11,5 +11,5 @@ spec:
       containers:
         - name: kube-state-metrics
           args:
-            - --metric-annotations-allowlist=pods=[injector.tumblr.com/request],deployments=[app.uw.systems/tier],statefulsets=[app.uw.systems/tier]
+            - --metric-annotations-allowlist=pods=[injector.tumblr.com/request],deployments=[app.uw.systems/owner,app.uw.systems/system,app.uw.systems/tier],statefulsets=[app.uw.systems/owner,app.uw.systems/system,app.uw.systems/tier]
             - --metric-labels-allowlist=namespaces=[uw.systems/owner],pods=[app,app.kubernetes.io/name],nodes=[role,topology.kubernetes.io/zone,uw.systems/rebooting]


### PR DESCRIPTION
On the back of tier information being useful in setting alerts and improving their behaviour request to allow `app.uw.systems/owner` and `app.uw.systems/system` for deployments and statetulsets.