### PR TITLE
Exit on error during vault initContainer auth requests

### DIFF
--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -294,7 +294,7 @@ spec:
           spec:
             initContainers:
               - name: vault-credentials
-                image: vault:1.8.4
+                image: docker.io/hashicorp/vault:1.15.2
                 command:
                   - sh
                   - -c
@@ -307,6 +307,7 @@ spec:
                                 config = {
                                     role = "{{ VKAC_ENVIRONMENT }}_aws_{{ POD_NAMESPACE }}_{{ POD_SERVICE_ACCOUNT }}"
                                 }
+                                exit_on_err = true
                             }
 
                             sink "file" {


### PR DESCRIPTION
Otherwise we saw that this can loop indefinitely in case the CA cert is read during the daily cert rotation. Also bump vault image to the latest available