### PR TITLE
Make ArgoCD aware of durations on Certificates

### DIFF
--- a/argocd/namespaced/argocd-cm-patch.yaml
+++ b/argocd/namespaced/argocd-cm-patch.yaml
@@ -62,3 +62,7 @@ data:
   resource.customizations.ignoreResourceUpdates.all: |
     jsonPointers:
       - /status
+
+  resource.customizations.knownTypeFields.cert-manager.io_Certificate: |
+    - field: spec.duration
+      type: meta/v1/Duration


### PR DESCRIPTION
Now that we're running ArgoCD 2.10.0 I'd like to try out a fix[1] for an issue we saw when ArgoCD would try to diff on fields that are durations[2]

[1] https://github.com/argoproj/argo-cd/commit/a7d0da941cc9d92f3aef19acc0c898a43fee3b16
[2] https://github.com/utilitywarehouse/dev-enablement-mono/commit/4bd52e4144612636fb78e30b563dab7cb20d05e7