### PR TITLE
Increase coredns memory limits

### DIFF
--- a/coredns/kustomization.yaml
+++ b/coredns/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
         path: /spec/template/spec/nodeSelector
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 170Mi
+        value: 512Mi
     target:
       kind: Deployment
       name: coredns


### PR DESCRIPTION
It's running close to the limit on prod-aws and it's a core workload so we don't need to be stingy with limits.