### PR TITLE
Deploy aws-cloud-controller-manager based on role=master label

### DIFF
--- a/cloud-provider-aws/kustomization.yaml
+++ b/cloud-provider-aws/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patches:
   - path: affinity-patch.yaml
   - path: args-patch.yaml
+  - path: node-selector-patch.yaml

--- a/cloud-provider-aws/node-selector-patch.yaml
+++ b/cloud-provider-aws/node-selector-patch.yaml
@@ -1,0 +1,14 @@
+# Schedule on nodes labelled via kubelet as role=master. This os to avoid a
+# dependency on our kube-master-node-labeller and instead be able to schedule
+# pods right away on fresh nodes
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      nodeSelector: 
+        $patch: replace
+        role: master


### PR DESCRIPTION
To avoid waiting on kube-master-node-labeller to decorate nodes that we have already labelled via kubelet when registered