### PR TITLE
Switch aws-cloud-controller-manager to hostNetwork

### DIFF
--- a/cloud-provider-aws/hostNetwork-patch.yaml
+++ b/cloud-provider-aws/hostNetwork-patch.yaml
@@ -1,0 +1,12 @@
+# Use host networking so that we do not rely on calico-node to be running on a
+# node before being able to schedule cloud conteoller manager pods. This should
+# untie the controller from calico deployment.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      hostNetwork: true

--- a/cloud-provider-aws/hostNetwork-patch.yaml
+++ b/cloud-provider-aws/hostNetwork-patch.yaml
@@ -1,5 +1,5 @@
 # Use host networking so that we do not rely on calico-node to be running on a
-# node before being able to schedule cloud conteoller manager pods. This should
+# node before being able to schedule cloud controller manager pods. This should
 # untie the controller from calico deployment.
 apiVersion: apps/v1
 kind: DaemonSet

--- a/cloud-provider-aws/kustomization.yaml
+++ b/cloud-provider-aws/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 patches:
   - path: affinity-patch.yaml
   - path: args-patch.yaml
+  - path: hostNetwork-patch.yaml
   - path: node-selector-patch.yaml


### PR DESCRIPTION
To remove the dependency with calico being up and running on a node before scheduling new pods