### PR TITLE
Confgure falcosidekick redis volume size

### DIFF
--- a/falco/gen-yaml
+++ b/falco/gen-yaml
@@ -5,5 +5,11 @@ helm repo add falcosecurity https://falcosecurity.github.io/charts
 helm repo update
 # Generate manifests but delete dummy Secrets. We should create them downstream
 # and use strongbox to encrypt.
-helm template falco -n sys-falco --set driver.kind=ebpf --set tty=true falcosecurity/falco --version=${FALCO_CHART_VERSION} --set falcosidekick.enabled=true --set falcosidekick.webui.enabled=true |\
+helm template falco -n sys-falco \
+  --set driver.kind=ebpf \
+  --set tty=true falcosecurity/falco \
+  --version=${FALCO_CHART_VERSION} \
+  --set falcosidekick.enabled=true \
+  --set falcosidekick.webui.enabled=true \
+  --set falcosidekick.webui.redis.storageSize=10Gi |\
   awk  'BEGIN{RS="---\n"; ORS="---\n"} !match($0, /kind: Secret\nmetadata/) {print}'> upstream.yaml

--- a/falco/upstream.yaml
+++ b/falco/upstream.yaml
@@ -771,7 +771,7 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi
 ---
 # Source: falco/charts/falcosidekick/templates/tests/test-connection.yaml
 apiVersion: v1


### PR DESCRIPTION
Set helm variable to configure the size of redis PVC and bump to 10Gi (from the default 1Gi) to allow it to breath in busier envs.