### PR TITLE
Start ingesting promtail logs

### DIFF
--- a/promtail/promtail.yaml
+++ b/promtail/promtail.yaml
@@ -12,7 +12,6 @@ spec:
         name: promtail
         policy.semaphore.uw.io/name: promtail
       annotations:
-        fluentbit.io/exclude: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "9080"
         prometheus.io/scrape: "true"


### PR DESCRIPTION
Until now we have excluded logs from the logging pipeline, since we had issues of excessive logging during high load situations making the load worse.

Issues happened when our pipeline used fluentd/fluentbit and graylog.

We think that the new tools (vector, promtail and loki) may have better logging policies, and thus we have decided to stop excluding their logs.