### PR TITLE
CoreDNS v1.11.1

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -2,8 +2,8 @@
 .PHONY: get-upstream
 
 # https://github.com/kubernetes/kubernetes
-# 1.10.1
-COMMIT_REF=39e52449f9f40aa34037b81396a602803baf4991
+# 1.11.1
+COMMIT_REF=78538bd303d49ddb4c7cb9daaf212fa7d0c75895
 
 get-upstream:
 	curl -Ls \

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.10.1
+        image: registry.k8s.io/coredns/coredns:v1.11.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Latest commit under kubernetes/kubernetes repo bumping CoreDNS version is: https://github.com/kubernetes/kubernetes/commit/78538bd303d49ddb4c7cb9daaf212fa7d0c75895 This is only updating to v1.11.1 (instead of latest: v1.11.3) so let's keep following this.