### PR TITLE
Increase limits for node-exporter

### DIFF
--- a/node-exporter/namespaced/daemonset.yaml
+++ b/node-exporter/namespaced/daemonset.yaml
@@ -36,8 +36,8 @@ spec:
               cpu: 0m
               memory: 24Mi
             limits:
-              cpu: 300m
-              memory: 128Mi
+              cpu: 1000m
+              memory: 256Mi
           ports:
             - containerPort: 9100
               hostPort: 9100


### PR DESCRIPTION
We observed alerts CPU throttling agents. Looking across the board its
not uncommon for agents to use between 0.02 and 0.03 vCPU on-prem, so
increase overall limits to more generous values.
