### PR TITLE
Disallow deprecated traefik APIs

### DIFF
--- a/kyverno/policies-audit-only/audit-only.yaml
+++ b/kyverno/policies-audit-only/audit-only.yaml
@@ -44,6 +44,13 @@ metadata:
 spec:
   validationFailureAction: Audit
 ---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-deprecated-traefik-apis
+spec:
+  validationFailureAction: Audit
+---
 # namespaces
 ---
 apiVersion: kyverno.io/v1

--- a/kyverno/policies/ingress/deprecated-traefik-apis.yaml
+++ b/kyverno/policies/ingress/deprecated-traefik-apis.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-deprecated-traefik-apis
+  annotations:
+    policies.kyverno.io/title: Disallow deprecated Traefik APIs
+    policies.kyverno.io/description: >-
+      Traefik deprecated traefik.containo.us API and mover to traefik.io. We
+      should replace all existing references and not allow new admissions in
+      order to be able to migrate to v3.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: check-deprecated-apis
+    match:
+      any:
+      - resources:
+          kinds:
+          - traefik.containo.us/v1alpha1/*
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated.
+        Please use traefik.io/v1alpha1/{{ request.object.kind }} instead.
+      deny: {}

--- a/kyverno/policies/ingress/kustomization.yaml
+++ b/kyverno/policies/ingress/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- deprecated-traefik-apis.yaml
 - disallow-default-tsloptions.yaml
 - disallow-or-operator.yaml
 - disallow-wildcard-hostsni.yaml


### PR DESCRIPTION
This should help ensure that old API resources won't re-appear after we migrate them in a cluster.
Example error message:
```
disallow-deprecated-traefik-apis:
  check-deprecated-apis: traefik.containo.us/v1alpha1/IngressRoute is deprecated.
    Please use traefik.io/v1alpha1/IngressRoute instead.
```