### PR TITLE
Revert "do not repeat ENVs in init containers"

### DIFF
--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -170,6 +170,10 @@ spec:
                   - -listen-address=127.0.0.1:8198
                   - -operational-address=:8199
                 env:
+                  - name: GCE_METADATA_HOST
+                    value: "127.0.0.1:8198"
+                  - name: GCE_METADATA_ROOT
+                    value: "127.0.0.1:8198"
                   - name: VAULT_CACERT
                     value: "/etc/tls/ca.crt"
                   - name: VAULT_ADDR
@@ -255,6 +259,10 @@ spec:
                   - sidecar
                   - -vault-role={{ VKAC_ENVIRONMENT }}_gcp_{{ POD_NAMESPACE }}_{{ POD_SERVICE_ACCOUNT }}
                 env:
+                  - name: GCE_METADATA_HOST
+                    value: "127.0.0.1:8098"
+                  - name: GCE_METADATA_ROOT
+                    value: "127.0.0.1:8098"
                   - name: VAULT_CACERT
                     value: "/etc/tls/ca.crt"
                   - name: VAULT_ADDR
@@ -368,11 +376,15 @@ spec:
                     ' > config.hcl
                     /usr/bin/dumb-init -- vault agent -config=config.hcl
                 env:
+                  - name: AWS_SHARED_CREDENTIALS_FILE
+                    value: "/etc/aws/credentials"
                   - name: VAULT_CACERT
                     value: "/etc/tls/ca.crt"
                   - name: VAULT_ADDR
                     value: "https://vault.sys-vault:8200"
                 volumeMounts:
+                  - name: vault-aws-credentials
+                    mountPath: /etc/aws
                   - name: vault-tls
                     mountPath: /etc/tls
               - (name): "*"


### PR DESCRIPTION
This reverts commit 2bde9afb151093c33a2b7b33a8aa9e44cc6013d3. kyverno do not set env new init containers added by policy