### PR TITLE
Enforce throttling over a longer window

### DIFF
--- a/vector/node/namespaced/resources/pods.yaml
+++ b/vector/node/namespaced/resources/pods.yaml
@@ -42,8 +42,8 @@ transforms:
       - kubernetes_remap
     type: throttle
     key_field: '{{ limit_key }}'
-    threshold: 10
-    window_secs: 1
+    threshold: 100
+    window_secs: 10
 
 sinks:
   loki_kubernetes:


### PR DESCRIPTION
To allow apps for small bursts of logs when they error