### PR TITLE
Hard-code key path in the startup probe

### DIFF
--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -331,7 +331,7 @@ spec:
                     command:
                       - test
                       - -e
-                      - ${GOOGLE_APPLICATION_CREDENTIALS}
+                      - /gcp/sa.json
                   failureThreshold: 5
                   periodSeconds: 15
                 args:


### PR DESCRIPTION
The env var doesn't seem to work for the startup probe
