### PR TITLE
Fix aws-gcp-key gcp sidecar ports

### DIFF
--- a/kyverno/policies/pods/injectSidecar.yaml
+++ b/kyverno/policies/pods/injectSidecar.yaml
@@ -531,6 +531,8 @@ spec:
                   - sidecar
                   - -vault-static-account={{ VKAC_ENVIRONMENT }}_gcp_{{ POD_NAMESPACE }}_{{ POD_SERVICE_ACCOUNT }}
                   - -secret-type=service_account_key
+                  - -listen-address=127.0.0.1:8198
+                  - -operational-address=:8199
                 env:
                   - name: GOOGLE_APPLICATION_CREDENTIALS
                     value: "/gcp/sa.json"


### PR DESCRIPTION
The operational status server and webserver ports are overlapping
between aws and gcp sidecars. Changing the ports for GCP sidecar to
match the gcp-token setup.
