### PR TITLE
Revert Bump CoreDNS to v1.12.0 #415

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -2,8 +2,8 @@
 .PHONY: get-upstream
 
 # https://github.com/kubernetes/kubernetes
-# 1.12.0
-COMMIT_REF=7429380b1cacebde73084ad3cb6fb676c69bd6b8
+# 1.11.1
+COMMIT_REF=78538bd303d49ddb4c7cb9daaf212fa7d0c75895
 
 get-upstream:
 	curl -Ls \

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: coredns
-          image: registry.k8s.io/coredns/coredns:v1.12.0
+          image: registry.k8s.io/coredns/coredns:v1.11.1
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
Made a mistake and pasted wrong commit hash here. I don't have the
correct one because https://github.com/kubernetes/kubernetes is
not yet updated for CoreDNS v1.12.0
