### PR TITLE
Bump coredns to v1.12.0

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -2,8 +2,8 @@
 .PHONY: get-upstream
 
 # https://github.com/kubernetes/kubernetes
-# 1.11.1
-COMMIT_REF=78538bd303d49ddb4c7cb9daaf212fa7d0c75895
+# 1.12.0
+COMMIT_REF=fb47caa689fedc68e916623d09808f6979c2c295
 
 get-upstream:
 	curl -Ls \

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -6,8 +6,8 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,23 +17,23 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - services
-      - pods
-      - namespaces
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -49,9 +49,9 @@ roleRef:
   kind: ClusterRole
   name: system:coredns
 subjects:
-  - kind: ServiceAccount
-    name: coredns
-    namespace: kube-system
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -59,7 +59,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
+      addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {
@@ -118,74 +118,74 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: k8s-app
-                      operator: In
-                      values: ["kube-dns"]
-                topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values: ["kube-dns"]
+              topologyKey: kubernetes.io/hostname
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-        - name: coredns
-          image: registry.k8s.io/coredns/coredns:v1.11.1
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              memory: $DNS_MEMORY_LIMIT
-            requests:
-              cpu: 100m
-              memory: 70Mi
-          args: ["-conf", "/etc/coredns/Corefile"]
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/coredns
-              readOnly: true
-          ports:
-            - containerPort: 53
-              name: dns
-              protocol: UDP
-            - containerPort: 53
-              name: dns-tcp
-              protocol: TCP
-            - containerPort: 9153
-              name: metrics
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 5
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8181
-              scheme: HTTP
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              add:
-                - NET_BIND_SERVICE
-              drop:
-                - all
-            readOnlyRootFilesystem: true
+      - name: coredns
+        image: registry.k8s.io/coredns/coredns:v1.12.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: $DNS_MEMORY_LIMIT
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:
         - name: config-volume
           configMap:
             name: coredns
             items:
-              - key: Corefile
-                path: Corefile
+            - key: Corefile
+              path: Corefile
 ---
 apiVersion: v1
 kind: Service
@@ -205,12 +205,12 @@ spec:
     k8s-app: kube-dns
   clusterIP: $DNS_SERVER_IP
   ports:
-    - name: dns
-      port: 53
-      protocol: UDP
-    - name: dns-tcp
-      port: 53
-      protocol: TCP
-    - name: metrics
-      port: 9153
-      protocol: TCP
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP


### PR DESCRIPTION
The formating of `upstream/coredns.yaml` is changed because the last
revert wasn't done correctly https://github.com/utilitywarehouse/system-manifests/pull/417
