### PR TITLE
setting batch.max_bytes has no effect on individual large events

### DIFF
--- a/vector/node/namespaced/resources/pods.yaml
+++ b/vector/node/namespaced/resources/pods.yaml
@@ -41,7 +41,7 @@ transforms:
     inputs:
       - kubernetes_remap
     type: throttle
-    key_field: '{{ limit_key }}'
+    key_field: "{{ limit_key }}"
     threshold: 100
     window_secs: 10
 
@@ -54,15 +54,12 @@ sinks:
     path: /loki/api/v1/push
     encoding:
       codec: text
-    batch:
-      # under loki's "max entry size" of 262144
-      max_bytes: 250000
     labels:
       cloud_provider: "${CLOUD_PROVIDER}"
       uw_environment: "${UW_ENVIRONMENT}"
       kubernetes_cluster: "${KUBERNETES_CLUSTER}"
-      app: '{{ app }}'
-      app_kubernetes_io_name: '{{ app }}'
-      kubernetes_namespace: '{{ kubernetes.pod_namespace }}'
-      kubernetes_pod_name: '{{ kubernetes.pod_name }}'
-      kubernetes_container: '{{ kubernetes.container_name }}'
+      app: "{{ app }}"
+      app_kubernetes_io_name: "{{ app }}"
+      kubernetes_namespace: "{{ kubernetes.pod_namespace }}"
+      kubernetes_pod_name: "{{ kubernetes.pod_name }}"
+      kubernetes_container: "{{ kubernetes.container_name }}"


### PR DESCRIPTION
Reverting max_bytes since testing shows logs larger then `batch.max_bytes` are still sent to loki.

There is already an issue on vector regarding this..
* https://github.com/vectordotdev/vector/issues/9790#issuecomment-2017482040
* https://github.com/vectordotdev/vector/issues/20169

This might be the solution if implemented
https://github.com/vectordotdev/vector/issues/8705
