### PR TITLE
Revert "test effect of ignoring replicasets on Reconciliation (#439)"

### DIFF
--- a/argocd/namespaced/argocd-cm-patch.yaml
+++ b/argocd/namespaced/argocd-cm-patch.yaml
@@ -92,7 +92,3 @@ data:
       - GlobalContextEntry
       - ReportChangeRequest
       - UpdateRequest
-    - apiGroups:
-      - apps
-      kinds:
-      - ReplicaSet


### PR DESCRIPTION
This reverts commit 9386226f21c79d1dafbfc4babc75df843d30fe0f. This config has no effect on Reconciliation Activity.