### PR TITLE
Stop dropping calico-apiserver info logs

### DIFF
--- a/promtail/promtail-config.yaml
+++ b/promtail/promtail-config.yaml
@@ -25,11 +25,6 @@ scrape_configs:
           selector: '{fluentbit_io_exclude="true"}'
           action: drop
           drop_counter_reason: "fluentbit_io_exclude"
-      # https://github.com/projectcalico/calico/issues/7988
-      - match:
-          selector: '{kubernetes_pod_name=~"calico-apiserver.+"} |~ "level=info|called with key"'
-          action: drop
-          drop_counter_reason: promtail_noisy_error
       # Traefik logs all broken config - repeatedly. We have no control over
       # this as team's create and manage IngressRoute/Service/Middleware. We
       # can chase fixes but broken config returns before long. This only

--- a/vector/node/namespaced/resources/pods.yaml
+++ b/vector/node/namespaced/resources/pods.yaml
@@ -11,15 +11,9 @@ transforms:
     type: filter
     condition: '.kubernetes.pod_labels.fluentbit_io_exclude != "true"'
 
-  drop_calico:
-    inputs:
-      - drop_exclude
-    type: filter
-    condition: '!(.kubernetes.pod_name == "calico-apiserver" && (contains(string!(.message), "level=info") || contains(string!(.message), "called with key")))'
-
   drop_traefik:
     inputs:
-      - drop_calico
+      - drop_exclude
     type: filter
     condition: '!(starts_with(string!(.kubernetes.pod_namespace), "sys-ingress-") && (contains(string!(.message), "kubernetes service not found") || contains(string!(.message), "subset not found for") || contains(string!(.message), "service port not found") || contains(string!(.message), "Cannot create service: service not found") || contains(string!(.message), "Skipping service: no endpoints found") || (contains(string!(.message), "middleware") && contains(string!(.message), "does not exist"))))'
 


### PR DESCRIPTION
The log drop workaround is no longer necessary since https://github.com/projectcalico/calico/pull/9600