### PR TITLE
Revert "Upgrade GCP CSI driver v1.17.2 (#463)"

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver/csi-gce-pd-controller-patch.yaml
+++ b/gcp-compute-persistent-disk-csi-driver/csi-gce-pd-controller-patch.yaml
@@ -30,9 +30,10 @@ spec:
         # Keeps upstream manifests and adds CrossNamespaceVolumeDataSource=true feature gate
         - name: csi-provisioner
           args:
-            - --v=2 # upstream is 5
+            - --v=2
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
+            - --feature-gates=CrossNamespaceVolumeDataSource=true
             - --http-endpoint=:22011
             - --leader-election-namespace=$(PDCSI_NAMESPACE)
             - --timeout=250s
@@ -40,8 +41,6 @@ spec:
             - --leader-election
             - --default-fstype=ext4
             - --controller-publish-readonly=true
-            - --feature-gates=VolumeAttributesClass=true # end of upstream opts
-            - --feature-gates=CrossNamespaceVolumeDataSource=true
       volumes:
         - $patch: delete
           name: cloud-sa-volume

--- a/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
+++ b/gcp-compute-persistent-disk-csi-driver/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: kube-system
 # Use a commit ref instead of tag, as images do not follow tags in the repo
 #  manifests.
 resources:
-  - github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/overlays/stable-master?ref=efb4c18479363c271d69a36afef439513ce7186b # v1.17.2
+  - github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/overlays/stable-master?ref=484cb85ff049c82d52b0d17c046d8ad59f334906
 
 patches:
   - path: csi-gce-pd-controller-patch.yaml


### PR DESCRIPTION
This reverts commit 8f4dde6381e0182625c906044a68e9845a591df9.

docker pull registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.17.2
Error response from daemon: manifest for registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.17.2 not found: manifest unknown: Failed to fetch "v1.17.2"
