### PR TITLE
Revert coredns to 1.14.2, following kube

### DIFF
--- a/coredns/Makefile
+++ b/coredns/Makefile
@@ -2,8 +2,8 @@
 .PHONY: get-upstream
 
 # https://github.com/kubernetes/kubernetes
-# 1.14.3
-COMMIT_REF=548ace71c0fc153c5903475b9ee9b94bff37fef0
+# 1.14.2
+COMMIT_REF=fc1726397e13fadd371b1aabd1b14c222908bfee
 
 get-upstream:
 	curl -Ls \

--- a/coredns/upstream/coredns.yaml
+++ b/coredns/upstream/coredns.yaml
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.14.3
+        image: registry.k8s.io/coredns/coredns:v1.14.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Reason is that 1.14.3 don't have arm images. We are not affected by the issue, but prefer to run the same as upstream kubernetes, for safety.