### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/otel-kafka/upstream/kafka.yaml
+++ b/otel-kafka/upstream/kafka.yaml
@@ -391,7 +391,7 @@ spec:
       initContainers:
         
         - name: prepare-config
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -583,7 +583,7 @@ spec:
               readOnly: true
       containers:
         - name: kafka
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/pubsub/msk-admin-client/statefulset.yaml
+++ b/pubsub/msk-admin-client/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
               memory: 4Gi
         # container used for executing kafka client commands on the MSK cluster
         - name: kafka-client
-          image: registry.uw.systems/bitnami/kafka:4.1.1-debian-12-r7
+          image: registry.uw.systems/soldevelo/kafka:4.1.1-debian-12-r0
           imagePullPolicy: IfNotPresent
           command: [ "/bin/sh", "-c", "--" ]
           # using trap + wait commands to exit the pod process when we get a SIGTERM or SIGINT


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:4.1.1-debian-12-r7` → [`soldevelo/kafka:4.1.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:4.0.0-debian-12-r10` → [`soldevelo/kafka:4.0.0-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)