### PR TITLE
fix(arc): install packages to arc runners for node-gyp to work

### DIFF
--- a/arc/runner/common-values.yaml
+++ b/arc/runner/common-values.yaml
@@ -27,7 +27,9 @@ template:
           - -c
           - |
             sudo apt-get update
-            sudo apt-get -y install make gettext-base
+            # build-essential (gcc/g++/make) and python3 are required by node-gyp
+            # to compile native node modules when no prebuilt binary is available
+            sudo apt-get -y install build-essential python3 gettext-base
             /home/runner/run.sh
         env:
           # Avoid forcing jobs to have a `container` section

--- a/arc/runner/system-dev-aws/generated-manifests.yaml
+++ b/arc/runner/system-dev-aws/generated-manifests.yaml
@@ -192,7 +192,7 @@ metadata:
     actions.github.com/scale-set-name: system-dev-aws
     actions.github.com/scale-set-namespace: sys-actions
   annotations:
-    actions.github.com/values-hash: 32c731d71886bcef90e0c39c7bc74f8302f98a783128029167adb0be2bc92ef
+    actions.github.com/values-hash: 55f4cba4348d32a1a736529d187e79b622c8e8ec0ab9532f1b039fd79fd64a7
     actions.github.com/cleanup-manager-role-binding: system-dev-aws-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: system-dev-aws-gha-rs-manager
     actions.github.com/cleanup-kubernetes-mode-role-binding-name: system-dev-aws-gha-rs-kube-mode
@@ -216,7 +216,9 @@ spec:
             - -c
             - |
               sudo apt-get update
-              sudo apt-get -y install make gettext-base
+              # build-essential (gcc/g++/make) and python3 are required by node-gyp
+              # to compile native node modules when no prebuilt binary is available
+              sudo apt-get -y install build-essential python3 gettext-base
               /home/runner/run.sh
           image: ghcr.io/actions/actions-runner:latest
           env:

--- a/arc/runner/system-dev-merit/generated-manifests.yaml
+++ b/arc/runner/system-dev-merit/generated-manifests.yaml
@@ -192,7 +192,7 @@ metadata:
     actions.github.com/scale-set-name: system-dev-merit
     actions.github.com/scale-set-namespace: sys-actions
   annotations:
-    actions.github.com/values-hash: 927bf439f9e88eab6b9759c893150303151f939e6b7318648615c3e72cfe2fd
+    actions.github.com/values-hash: b6684380844e508bc29f551fc09f18d951936ec69029b7f4adb5bc18e4a6aa4
     actions.github.com/cleanup-manager-role-binding: system-dev-merit-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: system-dev-merit-gha-rs-manager
     actions.github.com/cleanup-kubernetes-mode-role-binding-name: system-dev-merit-gha-rs-kube-mode
@@ -230,7 +230,9 @@ spec:
             - -c
             - |
               sudo apt-get update
-              sudo apt-get -y install make gettext-base
+              # build-essential (gcc/g++/make) and python3 are required by node-gyp
+              # to compile native node modules when no prebuilt binary is available
+              sudo apt-get -y install build-essential python3 gettext-base
               /home/runner/run.sh
           image: ghcr.io/actions/actions-runner:latest
           env:

--- a/arc/runner/system-exp-aws/generated-manifests.yaml
+++ b/arc/runner/system-exp-aws/generated-manifests.yaml
@@ -192,7 +192,7 @@ metadata:
     actions.github.com/scale-set-name: system-exp-aws
     actions.github.com/scale-set-namespace: sys-actions
   annotations:
-    actions.github.com/values-hash: cafb90b833398fdeff820e807574f9f2ce9ab65c519208fb41249476d284771
+    actions.github.com/values-hash: e771876e91afb3d340acabbc315ca206c3a80061e57b65ee9ee8855965280e0
     actions.github.com/cleanup-manager-role-binding: system-exp-aws-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: system-exp-aws-gha-rs-manager
     actions.github.com/cleanup-kubernetes-mode-role-binding-name: system-exp-aws-gha-rs-kube-mode
@@ -216,7 +216,9 @@ spec:
             - -c
             - |
               sudo apt-get update
-              sudo apt-get -y install make gettext-base
+              # build-essential (gcc/g++/make) and python3 are required by node-gyp
+              # to compile native node modules when no prebuilt binary is available
+              sudo apt-get -y install build-essential python3 gettext-base
               /home/runner/run.sh
           image: ghcr.io/actions/actions-runner:latest
           env:

--- a/arc/runner/system-exp-merit/generated-manifests.yaml
+++ b/arc/runner/system-exp-merit/generated-manifests.yaml
@@ -192,7 +192,7 @@ metadata:
     actions.github.com/scale-set-name: system-exp-merit
     actions.github.com/scale-set-namespace: sys-actions
   annotations:
-    actions.github.com/values-hash: 0be3f45089b6aaa0d1e155eefa196cc3a3c4ab909349099348812ddbf64dda0
+    actions.github.com/values-hash: 6bbea25190d51d088cf20681619d4978f2660b488a429fbc0453412e2979c24
     actions.github.com/cleanup-manager-role-binding: system-exp-merit-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: system-exp-merit-gha-rs-manager
     actions.github.com/cleanup-kubernetes-mode-role-binding-name: system-exp-merit-gha-rs-kube-mode
@@ -230,7 +230,9 @@ spec:
             - -c
             - |
               sudo apt-get update
-              sudo apt-get -y install make gettext-base
+              # build-essential (gcc/g++/make) and python3 are required by node-gyp
+              # to compile native node modules when no prebuilt binary is available
+              sudo apt-get -y install build-essential python3 gettext-base
               /home/runner/run.sh
           image: ghcr.io/actions/actions-runner:latest
           env:

--- a/arc/runner/system-prod-merit/generated-manifests.yaml
+++ b/arc/runner/system-prod-merit/generated-manifests.yaml
@@ -192,7 +192,7 @@ metadata:
     actions.github.com/scale-set-name: system-prod-merit
     actions.github.com/scale-set-namespace: sys-actions
   annotations:
-    actions.github.com/values-hash: c8e627caff899e21957f092f653c980bb7852833a18f6d419bdcd82c3513412
+    actions.github.com/values-hash: 731b65f3566bc5ba60216436b850efc0f1067cf08195ae468efe0a06edf30af
     actions.github.com/cleanup-manager-role-binding: system-prod-merit-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: system-prod-merit-gha-rs-manager
     actions.github.com/cleanup-kubernetes-mode-role-binding-name: system-prod-merit-gha-rs-kube-mode
@@ -216,7 +216,9 @@ spec:
             - -c
             - |
               sudo apt-get update
-              sudo apt-get -y install make gettext-base
+              # build-essential (gcc/g++/make) and python3 are required by node-gyp
+              # to compile native node modules when no prebuilt binary is available
+              sudo apt-get -y install build-essential python3 gettext-base
               /home/runner/run.sh
           image: ghcr.io/actions/actions-runner:latest
           env:


### PR DESCRIPTION
## Description

```
"node-pre-gyp WARN Pre-built binaries not installable for @sematext/gc-stats@1.5.8 and node@20.18.0 ... (falling back to source compile with node-gyp)"
"make: g++: No such file or directory"
"node-pre-gyp ERR! install response status 404 Not Found on https://github.com/adnanrahic/node-gcstats/archive/refs/tags/1.5.8.tar.gz"
```

* failure - https://github.com/utilitywarehouse/js-mono/actions/runs/28012560369/job/82913665812?pr=1155
* fix - https://github.com/utilitywarehouse/js-mono/actions/runs/28019083046/job/82935311930