### PR TITLE
Prepend vault init container instead of appending

### DIFF
--- a/kyverno/policies/vault/inject-vault-init-container-aws.yaml
+++ b/kyverno/policies/vault/inject-vault-init-container-aws.yaml
@@ -133,8 +133,8 @@ spec:
       jsonPatch:
         expression: >-
           (
-            size(object.spec.?initContainers.orValue([])) > 0 
-              ? [ JSONPatch{op: "add", path: "/spec/initContainers/-", value: variables.sidecar_payload} ]
+            size(object.spec.?initContainers.orValue([])) > 0
+              ? [ JSONPatch{op: "add", path: "/spec/initContainers/0", value: variables.sidecar_payload} ]
               : [ JSONPatch{op: "add", path: "/spec/initContainers", value: [variables.sidecar_payload]} ]
           ) + (
             size(object.spec.?volumes.orValue([])) > 0

--- a/kyverno/policies/vault/test/chainsaw-test.yaml
+++ b/kyverno/policies/vault/test/chainsaw-test.yaml
@@ -421,6 +421,14 @@ spec:
                       - name: vault-aws-credentials
                         mountPath: /etc/aws
                       - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  - name: init
+                    env:
+                      - name: AWS_SHARED_CREDENTIALS_FILE
+                        value: "/etc/aws/credentials"
+                    volumeMounts:
+                      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                      - name: vault-aws-credentials
+                        mountPath: /etc/aws
                 containers:
                   - name: app
                     env:

--- a/kyverno/policies/vault/test/test-inject-sidecar.yaml
+++ b/kyverno/policies/vault/test/test-inject-sidecar.yaml
@@ -57,6 +57,7 @@ metadata:
   annotations:
     uw.systems/kyverno-inject-sidecar-request: "vault-init-container-aws"
 spec:
+  initContainers: [{ name: init, image: alpine }]
   containers: [{ name: app, image: alpine }]
 ---
 # Fail-open Variants


### PR DESCRIPTION
The vault-credentials init container must run before any user-defined
init containers that depend on the AWS credentials it writes. The prior
JSONPatch appended it to the end of initContainers via
"/spec/initContainers/-", which the old patchStrategicMerge-based policy
avoided only as a side effect of listing it first in the patch. That
ordering guarantee was lost when the policy was converted to a
MutatingPolicy.

Argo Workflow pods add their own "init" container ahead of it, so it
runs without credentials and fails to reach S3 (seen on
qe-argo-workflows/test-artifact-upload in dev-merit). Inserting at
"/spec/initContainers/0" restores the guarantee that vault-credentials
always runs first.